### PR TITLE
Avoid showing multiple tracebacks to users

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -10,7 +10,7 @@ from leapp.logger import configure_logger
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.utils.audit import Execution, get_connection, get_checkpoints
 from leapp.utils.clicmd import command, command_opt
-from leapp.utils.output import report_errors
+from leapp.utils.output import report_errors, beautify_actor_exception
 
 
 def load_repositories_from(name, repo_path, manager=None):
@@ -91,5 +91,7 @@ def upgrade(args):
             msg = 'No such Actor: {}'.format(actor_name)
             logger.error(msg)
             raise CommandError(msg)
-    workflow.run(context=context, skip_phases_until=skip_phases_until)
+    with beautify_actor_exception():
+        workflow.run(context=context, skip_phases_until=skip_phases_until)
+
     report_errors(workflow.errors)

--- a/leapp/snactor/commands/run.py
+++ b/leapp/snactor/commands/run.py
@@ -6,7 +6,7 @@ from leapp.utils.clicmd import command, command_opt, command_arg
 from leapp.utils.repository import requires_repository, find_repository_basedir
 from leapp.logger import configure_logger
 from leapp.messaging.inprocess import InProcessMessaging
-from leapp.utils.output import report_errors
+from leapp.utils.output import report_errors, beautify_actor_exception
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.snactor.context import with_snactor_context
 
@@ -41,7 +41,8 @@ def cli(args):
     messaging = InProcessMessaging(stored=args.save_output)
     messaging.load(actor.consumes)
 
-    actor(messaging=messaging, logger=actor_logger).run()
+    with beautify_actor_exception():
+        actor(messaging=messaging, logger=actor_logger).run()
 
     report_errors(messaging.errors())
 

--- a/leapp/snactor/commands/workflow/run.py
+++ b/leapp/snactor/commands/workflow/run.py
@@ -8,7 +8,7 @@ from leapp.utils.clicmd import command_arg, command_opt
 from leapp.logger import configure_logger
 from leapp.utils.repository import requires_repository, find_repository_basedir
 from leapp.repository.scan import find_and_scan_repositories
-from leapp.utils.output import report_errors
+from leapp.utils.output import report_errors, beautify_actor_exception
 
 _LONG_DESCRIPTION = '''
 Executes the given workflow.
@@ -49,5 +49,8 @@ def cli(params):
         actor = repository.lookup_actor(actor_name)
         if actor:
             instance.whitelist_experimental_actor(actor)
-    instance.run(until_phase=params.until_phase, until_actor=params.until_actor)
+
+    with beautify_actor_exception():
+        instance.run(until_phase=params.until_phase, until_actor=params.until_actor)
+
     report_errors(instance.errors)

--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -1,8 +1,10 @@
 import json
 import sys
 from pprint import pformat
+from contextlib import contextmanager
 
 from leapp.models import ErrorModel
+from leapp.exceptions import LeappRuntimeError
 
 
 def _get_colors():
@@ -34,3 +36,19 @@ def print_error(error):
         actor=model.actor))
     if model.details:
         print('Detail: ' + pformat(json.loads(model.details)))
+
+
+@contextmanager
+def beautify_actor_exception():
+    try:
+        try:
+            yield
+        except LeappRuntimeError as e:
+            msg = '{} - Please check the above details'.format(e.message)
+            sys.stderr.write('\n')
+            sys.stderr.write('=' * len(msg) + '\n')
+            sys.stderr.write(msg + '\n')
+            sys.stderr.write('=' * len(msg) + '\n')
+            sys.stderr.write('\n')
+    finally:
+        pass


### PR DESCRIPTION
At the moment when an actor fails, two tracebacks are
thrown to the stderr. One for an actual failure in the actor
and the other (the last one) about the actor failure itself.
As the last traceback is not useful at all we shall keep only
the first one.