### PR TITLE
Packaging: persistent TIMESTAMP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ MASTER_BRANCH=master
 # upstream solution). For upstream builds N_REL=1;
 N_REL=`_NR=$${PR:+0}; if test "$${_NR:-1}" == "1"; then _NR=$${MR:+0}; fi; git rev-parse --abbrev-ref HEAD | grep -q "^$(MASTER_BRANCH)$$" || _NR=0;  echo $${_NR:-1}`
 
-TIMESTAMP=`date +%Y%m%d%H%MZ -u`
+_TIMESTAMP=$${TIMESTAMP:-`date +%Y%m%d%H%MZ -u`}
 SHORT_SHA=`git rev-parse --short HEAD`
 BRANCH=`git rev-parse --abbrev-ref HEAD | tr '-' '_'`
 
@@ -34,7 +34,7 @@ REQUEST=`if test -n "$$PR"; then echo ".PR$${PR}"; elif test -n "$$MR"; then ech
 #    0.201810080027Z.4078402.packaging
 #    0.201810080027Z.4078402.master.MR2
 #    1.201810080027Z.4078402.master
-RELEASE="$(N_REL).$(TIMESTAMP).$(SHORT_SHA).$(BRANCH)$(REQUEST)$(_SUFFIX)"
+RELEASE="$(N_REL).$(_TIMESTAMP).$(SHORT_SHA).$(BRANCH)$(REQUEST)$(_SUFFIX)"
 
 all: help
 
@@ -62,7 +62,13 @@ help:
 	@echo "  MR=6 COPR_CONFIG='path/to/the/config/copr/file' <target>"
 	@echo ""
 
-clean:
+# To ensure the TIMESTAMP will be same during the whole process, call the make
+# again with the expected parameters and with the set TIMESTAMP. By this magic
+# the TIMESTAMP will not be changed, even when some commands takes minutes.
+_remake:
+	@if test -z "$$TIMESTAMP"; then TIMESTAMP=$(_TIMESTAMP) $(MAKE) $@; exit 0; fi
+
+clean: _remake
 	@echo "--- Clean repo ---"
 	@rm -rf packaging/{sources,SRPMS}/
 	@rm -rf build/ dist/ *.egg-info
@@ -98,7 +104,7 @@ copr_build: srpm
 	@copr --config $(_COPR_CONFIG) build $(_COPR_REPO) \
 		packaging/SRPMS/${PKGNAME}-${VERSION}-${RELEASE}*.src.rpm
 
-print_release:
+print_release: _remake
 	@echo $(RELEASE)
 
 install-deps:


### PR DESCRIPTION
Previously, in case that between two calls of commands, where
the $(TIMESTAMP) have been included, have been processed in different
TIME (HH:MM), both commands result with different $(TIMESTAMP).

We want to proceed the make process with one persistant $(TIMESTAMP)
so we will avoid random errors related to the change of time. E.g.:
  cannot find prepared SRPM, because TIMESTAMP is different.
Problem is resolved in way that TIMESTAMP can be defined on the
cmdline. But to do not require it, special *_remake* target has been
added, which will call the make again with the TIMESTAMP value
in case the TIMESTAMP was not set.

Reproducer:
  1. Prepare Makefile like this:
```
TIMESTAMP=`date +%Y%m%d%H%MZ -u`
wait:
	@echo $(TIMESTAMP)
	@./wait_script.sh
	@echo $(TIMESTAMP)
```  
  2. call `make`