### PR TITLE
WIP: Do not fork actor execution with snactor fixture

### DIFF
--- a/leapp/snactor/fixture.py
+++ b/leapp/snactor/fixture.py
@@ -101,7 +101,7 @@ class ActorContext(object):
 
         :return: None
         """
-        self._actor(messaging=self._messaging).run()
+        self._actor(messaging=self._messaging, within_pytest=True).run()
 
     def messages(self):
         """


### PR DESCRIPTION
Previously running an actor within a test caused the test to be executed
in a forked process and when it was executing the actor the actor was
also being executed in another forked process.

This patch is removing the latter fork from being done to allow easier
mocking and testing.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>