### PR TITLE
Add commented libpython-selinux dependancy

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -85,6 +85,8 @@ Requires: python2-six
 Requires: python2-setuptools
 %endif
 Requires: findutils
+# selinux dependancy to be uncommented when it is suitable later
+# Requires: libselinux-python
 
 %description -n python2-%{name}
 Python 2 leapp framework libraries.


### PR DESCRIPTION
Only a placeholder for SELinux related check's requirement - libselinux-python - python2 lib.
Related to Invalid SELinux model fix and provided information leapp-repository
PR#27