### PR TITLE
docs: Include leapp.libraries.stdlib.api in the python documentation

### DIFF
--- a/docs/source/pydoc/leapp.libraries.stdlib.rst
+++ b/docs/source/pydoc/leapp.libraries.stdlib.rst
@@ -8,3 +8,8 @@ Module contents
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. automodule:: leapp.libraries.stdlib.api
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>