### PR TITLE
stdlib: Make api directly available in stdlib

### DIFF
--- a/leapp/libraries/stdlib/__init__.py
+++ b/leapp/libraries/stdlib/__init__.py
@@ -7,6 +7,8 @@ import six
 import subprocess
 import os
 
+from leapp.libraries.stdlib import api
+
 
 def call(args, split=True):
     """


### PR DESCRIPTION
Since I have been seeing some breaking usage of the api module by trying to import stdlib and using stdlib.api I added it as an import in the module to allow this.

After this change one can write this:
```python

from leapp.libraries import stdlib


stdlib.api.report_error(....)
```

Previously it was necessary to it like this:

```python
from leapp.libraries.stdlib import api

api.report_error(...)
```

Otherwise the api module wouldn't have been available.
