### PR TITLE
snactor: fix cryptic message without user repo config

### DIFF
--- a/leapp/repository/scan.py
+++ b/leapp/repository/scan.py
@@ -15,13 +15,16 @@ def _make_repo_lookup(include_locals):
 
     if include_locals:
         # Having it here allows to override global repositories with local ones.
-        data.update(get_user_config_repo_data()['repos'])
+        data.update(get_user_config_repo_data().get('repos', {}))
 
     return data
 
 
 def _resolve_repository_links(manager, include_locals):
     repo_lookup = _make_repo_lookup(include_locals=include_locals)
+    if not repo_lookup and manager.get_missing_repo_links():
+        # No repositories configured at all though missing links present
+        raise RepositoryConfigurationError('No repos configured? Try adding some with "snactor repo find"')
     finished = False
     while not finished:
         missing = manager.get_missing_repo_links()


### PR DESCRIPTION
If any snactor command is run before repos are
registered with snactor repo find command a
not much helping KeyError appears in error log,
because it isn't assumed that user repos may not
be configured at that point.
This patch addresses the issue by checking user repos
data presence and in case any missing links are found
raising RepositoryConfigurationError with a relevant
error message.

Closes-Issue: #357