### PR TITLE
snactor: Workflow run --save-output

### DIFF
--- a/leapp/snactor/commands/workflow/run.py
+++ b/leapp/snactor/commands/workflow/run.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import leapp.workflows
+import os
 import sys
 from leapp.exceptions import LeappError, UsageError, CommandError
 from leapp.snactor.commands.workflow import workflow
@@ -8,6 +9,7 @@ from leapp.utils.clicmd import command_arg, command_opt
 from leapp.logger import configure_logger
 from leapp.utils.repository import requires_repository, find_repository_basedir
 from leapp.repository.scan import find_and_scan_repositories
+from leapp.snactor.context import with_snactor_context
 from leapp.utils.output import report_errors, beautify_actor_exception
 
 _LONG_DESCRIPTION = '''
@@ -28,30 +30,42 @@ https://red.ht/leapp-docs
 @command_arg('name')
 @command_opt('until-phase', help='Runs until including the given phase but then exits')
 @command_opt('until-actor', help='Runs until including the given actor but then exits')
+@command_opt('save-output', is_flag=True,
+             help='Saves the output for actors to be consumable when executed with snactor run')
 @command_opt('--whitelist-experimental', action='append', metavar='ActorName',
              help='Enables experimental actors')
 @requires_repository
 def cli(params):
-    configure_logger()
-    repository = find_and_scan_repositories(find_repository_basedir('.'), include_locals=True)
-    try:
-        repository.load()
-    except LeappError as exc:
-        sys.stderr.write(exc.message)
-        sys.stderr.write('\n')
-        sys.exit(1)
+    def impl(context=None):
+        configure_logger()
+        repository = find_and_scan_repositories(find_repository_basedir('.'), include_locals=True)
+        try:
+            repository.load()
+        except LeappError as exc:
+            sys.stderr.write(exc.message)
+            sys.stderr.write('\n')
+            sys.exit(1)
 
-    wf = repository.lookup_workflow(params.name)
-    if not wf:
-        raise CommandError('Could not find any workflow named "{}"'.format(params.name))
+        wf = repository.lookup_workflow(params.name)
+        if not wf:
+            raise CommandError('Could not find any workflow named "{}"'.format(params.name))
 
-    instance = wf()
-    for actor_name in params.whitelist_experimental or ():
-        actor = repository.lookup_actor(actor_name)
-        if actor:
-            instance.whitelist_experimental_actor(actor)
+        instance = wf()
+        for actor_name in params.whitelist_experimental or ():
+            actor = repository.lookup_actor(actor_name)
+            if actor:
+                instance.whitelist_experimental_actor(actor)
 
-    with beautify_actor_exception():
-        instance.run(until_phase=params.until_phase, until_actor=params.until_actor)
+        with beautify_actor_exception():
+            instance.run(context=context, until_phase=params.until_phase, until_actor=params.until_actor)
 
-    report_errors(instance.errors)
+        report_errors(instance.errors)
+
+    @with_snactor_context
+    def snactor_context_impl():
+        impl(context=os.getenv('LEAPP_EXECUTION_ID'))
+
+    if params.save_output:
+        snactor_context_impl()
+    else:
+        impl()

--- a/leapp/snactor/context.py
+++ b/leapp/snactor/context.py
@@ -5,19 +5,29 @@ from leapp.utils.audit import get_connection, Execution
 from leapp.utils.clicmd import command_aware_wraps
 
 
+def last_snactor_context(connection=None):
+    """
+    Retrieves the last snactor-run context from the database. It generates a new one if none has been found.
+
+    :param connection: Database connection to use instead of the default connection.
+    :returns: String representing the latest snactor-run context uuid.
+    """
+    with get_connection(db=connection) as db:
+        cursor = db.execute('''
+            SELECT context, stamp FROM execution WHERE kind = 'snactor-run' ORDER BY stamp DESC LIMIT 1
+        ''')
+        row = cursor.fetchone()
+        if row:
+            context = row[0]
+        else:
+            context = str(uuid.uuid4())
+            Execution(context=context, kind='snactor-run', configuration='').store()
+        return context
+
+
 def with_snactor_context(f):
     @command_aware_wraps(f)
     def wrapper(*args, **kwargs):
-        with get_connection(None) as db:
-            cursor = db.execute("""
-              SELECT context, stamp FROM execution WHERE kind = 'snactor-run' ORDER BY stamp DESC LIMIT 1
-            """)
-            row = cursor.fetchone()
-            if row:
-                context = row[0]
-            else:
-                context = str(uuid.uuid4())
-                Execution(context=context, kind='snactor-run', configuration='').store()
-            os.environ["LEAPP_EXECUTION_ID"] = context
+        os.environ["LEAPP_EXECUTION_ID"] = last_snactor_context()
         return f(*args, **kwargs)
     return wrapper

--- a/leapp/utils/audit/__init__.py
+++ b/leapp/utils/audit/__init__.py
@@ -372,19 +372,20 @@ _MESSAGE_QUERY_TEMPLATE = '''
         WHERE context = ? AND type IN (%s)'''
 
 
-def get_messages(names, context):
+def get_messages(names, context, connection=None):
     """
     Queries all messages from the database for the given context and the list of model names
     :param names: List of names that should be messages returned for
     :type names: list or tuple of str
     :param context: Execution id the message should be queried from.
+    :param connection: Database connection to use instead of the default one.
     :return: Iterable with messages
     :rtype: iterable
     """
     if not names:
         return ()
 
-    with get_connection(None) as conn:
+    with get_connection(db=connection) as conn:
         cursor = conn.execute(_MESSAGE_QUERY_TEMPLATE % ', '.join('?' * len(names)), (context,) + tuple(names))
         cursor.row_factory = _dict_factory
         result = cursor.fetchall()


### PR DESCRIPTION
This implements a new feature for the `snactor workflow run` command,
that allows to store all messages from snactor workflow run to be
available for consumption by actor executed through `snactor run`.

Usage scenario:
---------------

One wants to write an actor that needs to consume from the
FactsCollection phase of the IPU workflow.

Before we introduced this parameter, one had to manually run every
actor, that is required to produce the messages the actor needs to
consume, manually with the --save-output parameter.

With the new feature one can now run:

$ snactor workflow run --save-output --until-phase FactsCollection ipu

And then can normally use `snactor run` to start testing the actor.

$ snactor run MyNewActor --print-output