### PR TITLE
Print a warning msg when missing model in "produces" tuple

### DIFF
--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -248,6 +248,10 @@ class Actor(object):
             for model in models:
                 if isinstance(model, type(self).produces):
                     self._messaging.produce(model, self)
+                else:
+                    self.log.warning('Actor is trying to produce a message of type "{}" without mentioning it '
+                                     'explicitely in the actor\'s "produces" tuple. The message will be ignored'.format(
+                                         type(model)))
 
     def consume(self, *models):
         """


### PR DESCRIPTION
Recently we spent some time with debugging "issue" with missing a model in produces tuple with @jmikovic and @shaded-enmity. This should help to save some time of actor developers.

Am I missing anything in this fix @vinzenz ? It does not have to be "AssertionError" of course.