### PR TITLE
snactor: fixed trace on topic creation

### DIFF
--- a/leapp/snactor/commands/new_topic.py
+++ b/leapp/snactor/commands/new_topic.py
@@ -2,7 +2,8 @@ import os
 
 import sys
 
-from leapp.utils.repository import make_class_name, make_name, find_repository_basedir
+from leapp.utils.repository import (make_class_name, make_name, find_repository_basedir,
+                                    requires_repository)
 from leapp.utils.clicmd import command_arg, command
 from leapp.exceptions import CommandError
 
@@ -16,6 +17,7 @@ https://red.ht/leapp-docs
 
 @command('new-topic', help='Creates a new topic')
 @command_arg('topic-name')
+@requires_repository
 def cli(args):
     topic_name = args.topic_name
     basedir = find_repository_basedir('.')

--- a/tests/scripts/test_snactor.py
+++ b/tests/scripts/test_snactor.py
@@ -1,8 +1,9 @@
 import json
 import os
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import check_call, check_output, CalledProcessError, STDOUT
 
 from helpers import repository_dir
+from leapp.exceptions import CommandError
 
 import pytest
 
@@ -28,6 +29,16 @@ def test_discovery(repository_dir):
     with type(repository_dir)(path=repository_dir.dirname).as_cwd():
         with pytest.raises(CalledProcessError):
             check_call(['snactor', 'discover'])
+
+
+def test_raises_create_outside_repository():
+    for cmd in ([['snactor', 'new-tag', 'winteriscoming'],
+                 ['snactor', 'new-topic', 'winteriscoming'],
+                 ['snactor', 'new-model', 'winteriscoming', '--topic', 'WinteriscomingTopic']]):
+        with pytest.raises(CalledProcessError) as err:
+            check_output(cmd, stderr=STDOUT)
+        assert ('This command must be executed from the repository directory' in
+                err.value.output.decode('utf-8'))
 
 
 def test_new_tag(repository_dir):


### PR DESCRIPTION
If a topic creation is attempted outside leapp repository
directory it will fail with a trace during os.path.join.
This fixes the issue by validating that command execution
takes place in the actual leapp repo directory.

Closes-Issue:#456