### PR TITLE
model.fields: Introduction of the JSON field type

### DIFF
--- a/tests/scripts/test_serialization.py
+++ b/tests/scripts/test_serialization.py
@@ -304,6 +304,13 @@ BASIC_TYPE_FIXTURES = (
     create_fixture(_create_field_string_list, ['a', 'b', 'c'], 'string_list_value'),
     create_fixture(_create_nested_base_model_field, BasicModel(message='Test message'), 'nested_model_value'),
     create_fixture(_create_string_enum_('YES', 'NO', 'MAYBE'), 'YES', 'string_enum_value', fail_values=('Woot',)),
+    create_fixture(fields.JSON, 2, 'json_integral_value'),
+    create_fixture(fields.JSON, 3.14, 'json_float_value'),
+    create_fixture(fields.JSON, 'some string', 'json_string_value'),
+    create_fixture(fields.JSON, ['a', 'b', 1, 2], 'json_list_value'),
+    create_fixture(fields.JSON, ('a', 'b', 1, 2), 'json_tuple_value'),
+    create_fixture(fields.JSON, {'a': [None, {'b': 'c'}], 'b': 2}, 'json_dict_value'),
+    create_fixture(fields.JSON, True, 'json_bool_value'),
 )
 
 


### PR DESCRIPTION
The JSON field type, is a fields that allows to assign any value that is
encodable to JSON by the json library of the python standard library.
With the exception for None value as the value itself. This is to keep
consistency with the rest of the fields, that require the field to be
marked as nullable. None value nested within, however is not restricted
by this limitation.

Example usage:
```python
class JsonUsedModel(Model):
    topic = SomeTopic

    data = fields.JSON()
    nullable_data = fields.Nullable(fields.JSON())

m = JsonUsedModel()

m.data = {'valid': None} # valid value
m.data = None # invalid value for this field

m.nullable_data = None # valid
m.nullable_data = {'valid': None} # valid value
```

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>