### PR TITLE
clicmd: Add support for tools without subcommands

### DIFF
--- a/leapp/utils/clicmd.py
+++ b/leapp/utils/clicmd.py
@@ -74,7 +74,10 @@ class Command(object):
         parser.register('action', 'parsers', _SubParserActionOverride)
         parser.add_argument('--version', action='version', version=version)
         parser.set_defaults(func=None)
-        s = parser.add_subparsers(title='Main commands', metavar='')
+        if self._sub_commands:
+            s = parser.add_subparsers(title='Main commands', metavar='')
+        else:
+            s = parser
         self.apply_parser(s, parser=parser)
         args = parser.parse_args()
         args.func(args)


### PR DESCRIPTION
Previously, it wasn't possible to write a simple tool, which does not
use subcommands. With this change, it allows to use the clicmd code also
for tools that do not use subcommands.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>