### PR TITLE
stdlib: Functions to check the current config

### DIFF
--- a/leapp/libraries/stdlib/config.py
+++ b/leapp/libraries/stdlib/config.py
@@ -1,0 +1,18 @@
+"""
+Functions that allow gather information about the current configuration.
+"""
+import os
+
+
+def is_debug():
+    """
+    Returns True if the LEAPP_DEBUG environment variable is set to '1'.
+    """
+    return os.getenv('LEAPP_DEBUG', '0') == '1'
+
+
+def is_verbose():
+    """
+    Returns True if either the LEAPP_DEBUG or the LEAPP_VERBOSE environment variable is set to '1'.
+    """
+    return os.getenv('LEAPP_DEBUG', '0') == '1' or os.getenv('LEAPP_VERBOSE', '0') == '1'

--- a/tests/scripts/test_stdlib.py
+++ b/tests/scripts/test_stdlib.py
@@ -1,4 +1,7 @@
+import os
+
 from leapp.libraries.stdlib import call
+from leapp.libraries.stdlib.config import is_debug, is_verbose
 
 
 def test_check_single_line_output():
@@ -19,3 +22,39 @@ def test_check_multiline_output():
 def test_check_multiline_output_no_split():
     a_command = ['echo', 'This a multi-\nline No Split test!']
     assert call(a_command, split=False) == u'This a multi-\nline No Split test!\n'
+
+
+def test_is_verbose(monkeypatch):
+    matrix = (
+        (('1', '1'), True),
+        (('0', '1'), True),
+        (('1', '0'), True),
+        (('0', '0'), False),
+        ((0, 1), False),
+        ((1, 1), False),
+        ((1, 0), False),
+        ((0, 0), False),
+        (('1', 0), True),
+        ((0, '1'), True)
+    )
+    for (debug, verbose), expected in matrix:
+        monkeypatch.setattr(os, 'environ', {'LEAPP_DEBUG': debug, 'LEAPP_VERBOSE': verbose})
+        assert is_verbose() == expected
+
+
+def test_is_debug(monkeypatch):
+    matrix = (
+        (('1', '1'), True),
+        (('0', '1'), False),
+        (('1', '0'), True),
+        (('0', '0'), False),
+        ((0, 1), False),
+        ((1, 1), False),
+        ((1, 0), False),
+        ((0, 0), False),
+        (('1', 0), True),
+        ((0, '1'), False)
+    )
+    for (debug, verbose), expected in matrix:
+        monkeypatch.setattr(os, 'environ', {'LEAPP_DEBUG': debug, 'LEAPP_VERBOSE': verbose})
+        assert is_debug() == expected


### PR DESCRIPTION
Previously environment variables for debug and verbose mode had to be
manually checked by doing comparison to a string.

For example:

```python
if os.getenv('LEAPP_DEBUG', '0') == '1':
    do_something_debuggy()
if os.getenv('LEAPP_VERBOSE', '0') ==  '1':
    do_something_verbose()
```

This has been a constant source of mistakes, by forgetting to put the
numbers in quotes. In addition to this, it is very verbose and not very
convenient. Thus this change introduces two new functions in the
standard library that can be used to check those variables.

is_debug() will return True if LEAPP_DEBUG has been set to '1'
is_verbose() will return True if either LEAPP_DEBUG or LEAPP_VERBOSE are
set to '1'

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>