### PR TITLE
Change default loglevel to ERROR

### DIFF
--- a/etc/leapp/logger.conf
+++ b/etc/leapp/logger.conf
@@ -19,7 +19,7 @@ handlers=stream
 
 [logger_root]
 level=DEBUG
-handlers=leapp_audit
+handlers=leapp_audit,stream
 
 [handler_leapp_audit]
 class=leapp.logger.LeappAuditHandler
@@ -28,6 +28,6 @@ args=()
 
 [handler_stream]
 class=StreamHandler
-level=NOTSET
+level=ERROR
 formatter=leapp
 args=(sys.stderr,)

--- a/leapp/logger/__init__.py
+++ b/leapp/logger/__init__.py
@@ -5,6 +5,7 @@ import os
 import time
 import sys
 
+from leapp.libraries.stdlib.config import is_debug, is_verbose
 from leapp.utils.audit import Audit
 _logger = None
 
@@ -72,10 +73,10 @@ def configure_logger():
             logging.getLogger('leapp').addHandler(handler)
             logging.StreamHandler().setLevel(logging.ERROR)
 
-        if os.getenv('LEAPP_VERBOSE', '0') == '1':
+        if is_verbose():
             for handler in logging.getLogger().handlers:
                 if isinstance(handler, logging.StreamHandler):
-                    handler.setLevel(logging.DEBUG if os.getenv('LEAPP_DEBUG', '0') == '1' else logging.INFO)
+                    handler.setLevel(logging.DEBUG if is_debug() else logging.INFO)
 
         _logger = logging.getLogger('leapp')
         _logger.info('Logging has been initialized')

--- a/leapp/logger/__init__.py
+++ b/leapp/logger/__init__.py
@@ -53,22 +53,29 @@ def configure_logger():
     global _logger
     if not _logger:
         path = os.getenv('LEAPP_LOGGER_CONFIG', '/etc/leapp/logger.conf')
-        log_format = '%(asctime)s.%(msecs)-3d %(levelname)-8s PID: %(process)d %(name)s: %(message)s'
-        log_date_format = '%Y-%m-%d %H:%M:%S'
+
         if path and os.path.isfile(path):
             logging.config.fileConfig(path)
         else:  # Fall back logging configuration
             logging.Formatter.converter = time.gmtime
+            log_format = '%(asctime)s.%(msecs)-3d %(levelname)-8s PID: %(process)d %(name)s: %(message)s'
+            log_date_format = '%Y-%m-%d %H:%M:%S'
+            logging.basicConfig(
+                level=logging.DEBUG,
+                format=log_format,
+                datefmt=log_date_format,
+                stream=sys.stderr,
+            )
             logging.getLogger('urllib3').setLevel(logging.WARN)
             handler = LeappAuditHandler()
             handler.setFormatter(logging.Formatter(fmt=log_format, datefmt=log_date_format))
             logging.getLogger('leapp').addHandler(handler)
+            logging.StreamHandler().setLevel(logging.ERROR)
 
         if os.getenv('LEAPP_VERBOSE', '0') == '1':
-            logging.getLogger('').setLevel(logging.DEBUG if os.getenv('LEAPP_DEBUG', '0') == '1' else logging.INFO)
-            handler = logging.StreamHandler(sys.stderr)
-            handler.setFormatter(logging.Formatter(fmt=log_format, datefmt=log_date_format))
-            logging.getLogger('').addHandler(handler)
+            for handler in logging.getLogger().handlers:
+                if isinstance(handler, logging.StreamHandler):
+                    handler.setLevel(logging.DEBUG if os.getenv('LEAPP_DEBUG', '0') == '1' else logging.INFO)
 
         _logger = logging.getLogger('leapp')
         _logger.info('Logging has been initialized')


### PR DESCRIPTION
When LEAPP_DEBUG is not 1, self.log.error() and self.log.critical() won't print anything to stderr.

This should be true for lower severities, but from error up, things should appear also on stderr.