### PR TITLE
stdlib: remove the call function

### DIFF
--- a/leapp/libraries/stdlib/__init__.py
+++ b/leapp/libraries/stdlib/__init__.py
@@ -75,30 +75,6 @@ class CalledProcessError(LeappError):
         return self._result.get('pid')
 
 
-def call(args, split=True):
-    """
-    Call an external program, capture and automatically utf-8 decode its output.
-    Then, suppress output to stderr and redirect to /dev/null.
-
-    :param args: Command to execute
-    :type args: list
-    :param split: Split the output on newlines
-    :type split: bool
-    :return: stdout output, 'utf-8' decoded, split by lines if split=True
-    :rtype: unicode/str or [unicode/str] if split=True
-    """
-
-    r = None
-    with open(os.devnull, mode='w') as err:
-        if six.PY3:
-            r = subprocess.check_output(args, stderr=err, encoding='utf-8')
-        else:
-            r = subprocess.check_output(args, stderr=err).decode('utf-8')
-    if split:
-        return r.splitlines()
-    return r
-
-
 def _logging_handler(fd_info, buffer):
     """
     Log into either STDOUT or to STDERR.

--- a/tests/scripts/test_stdlib.py
+++ b/tests/scripts/test_stdlib.py
@@ -1,27 +1,27 @@
 import os
 
-from leapp.libraries.stdlib import call
+from leapp.libraries.stdlib import run
 from leapp.libraries.stdlib.config import is_debug, is_verbose
 
 
 def test_check_single_line_output():
     a_command = ['echo', 'This a single line test!']
-    assert call(a_command) == [u'This a single line test!']
+    assert run(a_command, split=True)['stdout'] == [u'This a single line test!']
 
 
 def test_check_single_line_output_no_split():
     a_command = ['echo', 'This a single line No Split test!']
-    assert call(a_command, split=False) == u'This a single line No Split test!\n'
+    assert run(a_command, split=False)['stdout'] == u'This a single line No Split test!\n'
 
 
 def test_check_multiline_output():
     a_command = ['echo', 'This a multi-\nline test!']
-    assert call(a_command) == [u'This a multi-', u'line test!']
+    assert run(a_command, split=True)['stdout'] == [u'This a multi-', u'line test!']
 
 
 def test_check_multiline_output_no_split():
     a_command = ['echo', 'This a multi-\nline No Split test!']
-    assert call(a_command, split=False) == u'This a multi-\nline No Split test!\n'
+    assert run(a_command, split=False)['stdout'] == u'This a multi-\nline No Split test!\n'
 
 
 def test_is_verbose(monkeypatch):


### PR DESCRIPTION
We want to get rid of the subprocess library and we found the call
function as expendable as we want from people to use just `run` for
everything.