### PR TITLE
clicmd: Print help if a parent command is called

### DIFF
--- a/leapp/utils/clicmd.py
+++ b/leapp/utils/clicmd.py
@@ -7,6 +7,13 @@ from argparse import ArgumentParser, _SubParsersAction, RawDescriptionHelpFormat
 from leapp.exceptions import CommandDefinitionError, UsageError, CommandError
 
 
+class _LeappArgumentParser(ArgumentParser):
+    def error(self, message):
+        self.print_help()
+        sys.stderr.write('error: %s\n' % message)
+        sys.exit(2)
+
+
 class _LeappHelpFormatter(RawDescriptionHelpFormatter):
     """
     Capitalizes section headings in the help output
@@ -70,7 +77,7 @@ class Command(object):
         :type version: str
         :return: None
         """
-        parser = ArgumentParser(prog=os.path.basename(sys.argv[0]), formatter_class=_LeappHelpFormatter)
+        parser = _LeappArgumentParser(prog=os.path.basename(sys.argv[0]), formatter_class=_LeappHelpFormatter)
         parser.register('action', 'parsers', _SubParserActionOverride)
         parser.add_argument('--version', action='version', version=version)
         parser.set_defaults(func=None)


### PR DESCRIPTION
Previously when calling a command that has subcommand on the commandline
did not give the user any feedback on the usage.

As an example expected usage would be:
$ tool command subcommand

But the user would type:
$ tool command

The tool would silently and successfully exit.

With this change, the tool will now print the help and exit with exit
code 2.

Fixes #455

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>