### PR TITLE
stdlib.api: Add tools files api

### DIFF
--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -128,7 +128,25 @@ class Actor(object):
         """ Returns all common repository file paths. """
         return os.getenv("LEAPP_COMMON_FILES", "").split(":")
 
-    def _get_folder_path(self, directories, name):
+    @property
+    def actor_tools_paths(self):
+        """
+        Returns the tool paths that are bundled with the actor. (Path to the content of the actor's tools directory).
+        """
+        return os.getenv("LEAPP_TOOLS", "").split(":")
+
+    @property
+    def common_tools_paths(self):
+        """ Returns all common repository tool paths. """
+        return os.getenv("LEAPP_COMMON_TOOLS", "").split(":")
+
+    @property
+    def tools_paths(self):
+        """ Returns all actor tools paths related to the actor and common actors tools paths. """
+        return self.actor_tools_paths + self.common_tools_paths
+
+    @staticmethod
+    def _get_folder_path(directories, name):
         """
         Finds the first matching folder path within directories.
 
@@ -176,7 +194,8 @@ class Actor(object):
         """
         return self._get_folder_path(self.actor_files_paths, name)
 
-    def _get_file_path(self, directories, name):
+    @staticmethod
+    def _get_file_path(directories, name):
         """
         Finds the first matching file path within directories.
 
@@ -223,6 +242,55 @@ class Actor(object):
         :rtype: str or None
         """
         return self._get_file_path(self.actor_files_paths, name)
+
+    @staticmethod
+    def _get_tool_path(directories, name):
+        """
+        Finds the first matching executable file within directories.
+
+        :param name: Name of the file
+        :type name: str
+        :return: Found file path
+        :rtype: str or None
+        """
+        for path in directories:
+            path = os.path.join(path, name)
+            if os.path.isfile(path) and os.access(path, os.X_OK):
+                return path
+        return None
+
+    def get_tool_path(self, name):
+        """
+        Finds the first matching executable file path within :py:attr:`tools_paths`.
+
+        :param name: Name of the file
+        :type name: str
+        :return: Found file path
+        :rtype: str or None
+        """
+        return self._get_tool_path(self.tools_paths, name)
+
+    def get_common_tool_path(self, name):
+        """
+        Finds the first matching executable file path within :py:attr:`common_tools_paths`.
+
+        :param name: Name of the file
+        :type name: str
+        :return: Found file path
+        :rtype: str or None
+        """
+        return self._get_tool_path(self.common_tools_paths, name)
+
+    def get_actor_tool_path(self, name):
+        """
+        Finds the first matching executable file path within :py:attr:`actor_tools_paths`.
+
+        :param name: Name of the file
+        :type name: str
+        :return: Found file path
+        :rtype: str or None
+        """
+        return self._get_tool_path(self.actor_tools_paths, name)
 
     def run(self, *args):
         """ Runs the actor calling the method :py:func:`process`. """

--- a/leapp/libraries/stdlib/api.py
+++ b/leapp/libraries/stdlib/api.py
@@ -101,6 +101,23 @@ def common_files_paths():
     return current_actor().common_files_paths
 
 
+def actor_tools_paths():
+    """
+    Returns the tool paths that are bundled with the actor. (Path to the content of the actor's tools directory).
+    """
+    return current_actor().actor_tools_paths
+
+
+def tools_paths():
+    """ Returns all actor tools paths related to the actor and common actors tools paths. """
+    return current_actor().tools_paths
+
+
+def common_tools_paths():
+    """ Returns all common repository tool paths. """
+    return current_actor().common_tools_paths
+
+
 def get_common_folder_path(name):
     """
     Finds the first matching folder path within :py:attr:`files_paths`.
@@ -171,3 +188,39 @@ def get_file_path(name):
     :rtype: str or None
     """
     return current_actor().get_file_path(name)
+
+
+def get_tool_path(name):
+    """
+    Finds the first matching executable file path within :py:attr:`tools_paths`.
+
+    :param name: Name of the file
+    :type name: str
+    :return: Found file path
+    :rtype: str or None
+    """
+    return current_actor().get_tool_path(name)
+
+
+def get_common_tool_path(name):
+    """
+    Finds the first matching executable file path within :py:attr:`common_tools_paths`.
+
+    :param name: Name of the file
+    :type name: str
+    :return: Found file path
+    :rtype: str or None
+    """
+    return current_actor().get_common_tool_path(name)
+
+
+def get_actor_tool_path(name):
+    """
+    Finds the first matching executable file path within :py:attr:`actor_tools_paths`.
+
+    :param name: Name of the file
+    :type name: str
+    :return: Found file path
+    :rtype: str or None
+    """
+    return current_actor().get_actor_tool_path(name)

--- a/leapp/repository/__init__.py
+++ b/leapp/repository/__init__.py
@@ -134,6 +134,8 @@ class Repository(object):
         if not stage or stage is _LoadStage.LIBRARIES:
             self.log.debug("Extending PATH for common tool paths")
             self._extend_environ_paths('PATH', self.tools)
+            self.log.debug("Extending LEAPP_COMMON_TOOLS for common tool paths")
+            self._extend_environ_paths('LEAPP_COMMON_TOOLS', self.tools)
             self.log.debug("Extending LEAPP_COMMON_FILES for common file paths")
             self._extend_environ_paths('LEAPP_COMMON_FILES', self.files)
 

--- a/leapp/repository/actor_definition.py
+++ b/leapp/repository/actor_definition.py
@@ -238,6 +238,10 @@ class ActorDefinition(object):
         if self.files:
             os.environ['LEAPP_FILES'] = os.path.join(self._repo_dir, self._directory, self.files[0])
 
+        tools_backup = os.environ.get('LEAPP_TOOLS', None)
+        if self.tools:
+            os.environ['LEAPP_TOOLS'] = os.path.join(self._repo_dir, self._directory, self.tools[0])
+
         # We make a snapshot of the symbols in the module
         before = leapp.libraries.actor.__dict__.keys()
         # Now we are loading all modules and packages and injecting them at the same time into the modules at hand
@@ -264,6 +268,13 @@ class ActorDefinition(object):
             # Restoration of the LEAPP_FILES environment variable
             if files_backup is not None:
                 os.environ['LEAPP_FILES'] = files_backup
+            else:
+                os.environ.pop('LEAPP_FILES', None)
+
+            if tools_backup is not None:
+                os.environ['LEAPP_TOOLS'] = tools_backup
+            else:
+                os.environ.pop('LEAPP_TOOLS', None)
 
             # Remove all symbols in the actor lib before the execution
             current = leapp.libraries.actor.__dict__.keys()

--- a/tests/data/actor-api-tests/actors/first/tools/directory/exec_script
+++ b/tests/data/actor-api-tests/actors/first/tools/directory/exec_script
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'first-actor'

--- a/tests/data/actor-api-tests/actors/first/tools/directory/nonexec_script
+++ b/tests/data/actor-api-tests/actors/first/tools/directory/nonexec_script
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "first-actor"
+echo "Should not be executed"
+exit 1

--- a/tests/data/actor-api-tests/actors/first/tools/first-actor
+++ b/tests/data/actor-api-tests/actors/first/tools/first-actor
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'first-actor'

--- a/tests/data/actor-api-tests/actors/second/tools/directory/exec_script
+++ b/tests/data/actor-api-tests/actors/second/tools/directory/exec_script
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'second-actor'

--- a/tests/data/actor-api-tests/actors/second/tools/directory/nonexec_script
+++ b/tests/data/actor-api-tests/actors/second/tools/directory/nonexec_script
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "second-actor"
+echo "Should not be executed"
+exit 1

--- a/tests/data/actor-api-tests/actors/second/tools/second-actor
+++ b/tests/data/actor-api-tests/actors/second/tools/second-actor
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'second-actor'

--- a/tests/data/actor-api-tests/tools/directory/exec_script
+++ b/tests/data/actor-api-tests/tools/directory/exec_script
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'repository'

--- a/tests/data/actor-api-tests/tools/directory/nonexec_script
+++ b/tests/data/actor-api-tests/tools/directory/nonexec_script
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "repository"
+echo "Should not be executed"
+exit 1

--- a/tests/data/actor-api-tests/tools/repository
+++ b/tests/data/actor-api-tests/tools/repository
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'repository'


### PR DESCRIPTION
This change introduces an API for being able to retrieve the location of
executable tools within repo/tools or repo/actors/<actor>/tools
This allows to retrieve the full path to a tool bundled with the
repository or an actor just like we do support this for files.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>