### PR TITLE
leapp upgrade: Fail with exit code 1 after errors

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -125,6 +125,9 @@ def upgrade(args):
 
     report_errors(workflow.errors)
 
+    if workflow.errors:
+        sys.exit(1)
+
 
 @command('list-runs', help='List previous Leapp upgrade executions')
 def list_runs(args):


### PR DESCRIPTION
Previously, leapp upgrade would have return error code `0` even when
errors have been reported through the framework.

This change introduces the reporting of exit code `1` in case errors
have been reported.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>
Fixes #371 
Fixes #397 