### PR TITLE
stdlib.api: Use a fallback logger

### DIFF
--- a/leapp/libraries/stdlib/api.py
+++ b/leapp/libraries/stdlib/api.py
@@ -4,6 +4,8 @@ This module implements a convenience API for actions that are accessible to acto
 Any code that wants use this convenience library has to be called from within the actors context.
 This is true for actors, actor private libraries and repository libraries.
 """
+import logging
+
 from leapp.actors import Actor
 
 
@@ -50,7 +52,7 @@ def current_logger():
     :return: Logger instance for the current actor.
     :rtype: logging.Logger
     """
-    return current_actor().log
+    return current_actor().log if current_actor() else logging.getLogger('leapp.fallback')
 
 
 def produce(*model_instances):


### PR DESCRIPTION
`leapp.libraries.stdlib.api.current_logger` currently fails if no actor
is currently running. However this function is used by some other
libraries that, at least in test cases need to do the logging too.

This change introduces a fallback in case current_actor returns None.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>