### PR TITLE
Handle traceback when executed command is not found

### DIFF
--- a/tests/scripts/test_stdlib.py
+++ b/tests/scripts/test_stdlib.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from leapp.libraries.stdlib import CalledProcessError, run
+from leapp.libraries.stdlib import CalledProcessError, MissingCommandError, run
 from leapp.libraries.stdlib.config import is_debug, is_verbose
 
 
@@ -31,9 +31,27 @@ def test_check_error():
         run(a_command, checked=True)
 
 
+def test_check_error_with_path(monkeypatch):
+    monkeypatch.setattr(os, 'environ', {'PATH': None})
+    a_command = ['true']
+    with pytest.raises(MissingCommandError):
+        run(a_command, checked=True)
+
+
 def test_check_error_no_checked():
     a_command = ['false']
     assert run(a_command, checked=False)['exit_code'] == 1
+
+
+def test_check_non_existing():
+    a_command = ['non-existing']
+    with pytest.raises(MissingCommandError):
+        run(a_command, checked=True)
+
+
+def test_check_non_existing_no_checked():
+    a_command = ['non-existing']
+    assert run(a_command, checked=False) is None
 
 
 def test_is_verbose(monkeypatch):


### PR DESCRIPTION
When command is executed using stdlib.run function and it fails due to a missing or mistyped command, traceback with CalledProcessError (A Leapp Command Error occurred.) and OSError ([Errno 2] No such file or directory) occurs.

However if even both of these exceptions are caught, there is still a traceback:
<details>
    <summary>Click for the traceback</summary>

```
Traceback (most recent call last):
  File "/usr/bin/leapp", line 9, in <module>
    load_entry_point('leapp==0.6.0', 'console_scripts', 'leapp')()
  File "/usr/lib/python2.7/site-packages/leapp/cli/__init__.py", line 30, in main
    cli.command.execute('leapp version {}'.format(VERSION))
  File "/usr/lib/python2.7/site-packages/leapp/utils/clicmd.py", line 90, in execute
    args.func(args)
  File "/usr/lib/python2.7/site-packages/leapp/utils/clicmd.py", line 112, in called
    self.target(args)
  File "/usr/lib/python2.7/site-packages/leapp/cli/upgrade/__init__.py", line 124, in upgrade
    workflow.run(context=context, skip_phases_until=skip_phases_until)
  File "/usr/lib/python2.7/site-packages/leapp/workflows/__init__.py", line 210, in run
    if messaging.errors():
  File "/usr/lib/python2.7/site-packages/leapp/messaging/__init__.py", line 55, in errors
    return list(self._errors)
  File "<string>", line 2, in __len__
  File "/usr/lib64/python2.7/multiprocessing/managers.py", line 773, in _callmethod
    raise convert_to_error(kind, result)
multiprocessing.managers.RemoteError:
---------------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/managers.py", line 242, in serve_client
    obj, exposed, gettypeid = id_to_obj[ident]
KeyError: '7f9305620bd8'
---------------------------------------------------------------------------
```
</details>

The problem is in the [_call](https://github.com/oamg/leapp/blob/v0.6.0/leapp/libraries/stdlib/call.py#L81) function which executes the command in forked process.

This PR handles the traceback by raising a CalledProcessError exception (if the command is missing) before the command is executed.

Requires leapp-repository PR: oamg/leapp-repository#123