### PR TITLE
[WIP] Enable profilling when env LEAPP_CPROFILE == '1'

### DIFF
--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -88,7 +88,7 @@ def main():
     cli.command.execute(version=_('snactor version {}').format(VERSION))
     if profile_enabled:
         pr.disable()
-        s = StringIO.StringIO()
+        s = StringIO()
         sortby = 'cumulative'
         ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
         ps.print_stats()


### PR DESCRIPTION
Currently on some machines the run of the leapp / snactor is too
slow. Especially framework itself should be fast but sometimes the
time differences are in order of tens seconds. From this point,
it seems useful to be able to start profilling based on the env
variable when it is needed.