### PR TITLE
Workflow: add the is_checkpoint flag

### DIFF
--- a/leapp/workflows/__init__.py
+++ b/leapp/workflows/__init__.py
@@ -249,6 +249,9 @@ class Workflow(with_metaclass(WorkflowMeta)):
                     self.log.info('Initiating system reboot due to the restart_after_reboot flag')
                     reboot_system()
                 return
+            if phase[0].flags.is_checkpoint:
+                self.log.info('Stopping the workflow execution due to the is_checkpoint flag')
+                return
 
 
 def get_workflows():

--- a/leapp/workflows/flags.py
+++ b/leapp/workflows/flags.py
@@ -1,10 +1,15 @@
 class Flags(object):
     restart_after_phase = False
     request_restart_after_phase = False
+    is_checkpoint = False
 
-    def __init__(self, request_restart_after_phase=False, restart_after_phase=False):
+    def __init__(self,
+                 request_restart_after_phase=False,
+                 restart_after_phase=False,
+                 is_checkpoint=False):
         self.request_restart_after_phase = request_restart_after_phase
         self.restart_after_phase = restart_after_phase
+        self.is_checkpoint = is_checkpoint
 
     def serialize(self):
         """
@@ -12,5 +17,6 @@ class Flags(object):
         """
         return {
             'restart_after_phase': self.restart_after_phase,
-            'request_restart_after_phase': self.request_restart_after_phase
+            'request_restart_after_phase': self.request_restart_after_phase,
+            'is_checkpoint': self.is_checkpoint
         }


### PR DESCRIPTION
We need to stop the execution of the workflow in some cases without
the reboot requirement. Adding the flag to provide such functionality.