### PR TITLE
Use realpath when load actors?

### DIFF
--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -446,7 +446,10 @@ def get_actor_metadata(actor):
     additional_tag_info = ' At least one tag is required for actors. Please fill the tags field'
     return dict([
         ('class_name', actor.__name__),
-        ('path', os.path.dirname(sys.modules[actor.__module__].__file__)),
+        # TODO: missing tests. We need to ensure this doesn't break anything.
+        # # OTOH, actor_definition.inspect_actor ends with empty list on Python3
+        # # if path is not transformed into the realpath.
+        ('path', os.path.dirname(os.path.realpath(sys.modules[actor.__module__].__file__))),
         _get_attribute(actor, 'name', _is_type(string_types), required=True),
         _get_attribute(actor, 'tags', _is_tag_tuple, required=True, additional_info=additional_tag_info),
         _get_attribute(actor, 'consumes', _is_model_tuple, required=False, default_value=()),


### PR DESCRIPTION
~~The definition.full_path contains path through symlink, e.g.:
  /etc/leapp/repos.d/system_upgrade/...
and entry['path'] contains real path, e.g.:
  /usr/share/leapp-repositories/...
Not sure about the hidden idea but this is blocking us and we need to
resolve transition to Python3 asap... so - hacky way. Someone can fix
it properly later~~

EDIT:
    Use realpath when load actors?
    
    The definition.full_path contains path through symlink, e.g.:
      /usr/share/leapp-repositories/...
    and entry['path'] contains real path, e.g.:
      /etc/leapp/repos.d/system_upgrade/...
    Not sure about the hidden idea but this is blocking us and we need to
    resolve transition to Python3 asap... so. Not sure whether there is
    special use case for this. Currently all actors in leapp.actors
    use realpath.
