### PR TITLE
Temporary fix of leapp.stdlib

### DIFF
--- a/leapp/libraries/stdlib/__init__.py
+++ b/leapp/libraries/stdlib/__init__.py
@@ -76,6 +76,7 @@ class CalledProcessError(LeappError):
         return self._result.get('pid')
 
 
+# FIXME: Issue #488
 def __write_raw(fd_info, buffer):
     """
     Raw write to fd compatible in Py2 and Py3 (3.3+)
@@ -87,8 +88,13 @@ def __write_raw(fd_info, buffer):
     :param buffer: buffer interface
     :type buffer: bytes array
     """
-    (fd, fd_type) = fd_info
+    (unused_fd, fd_type) = fd_info
     if sys.version_info > (3, 0):
+        if fd_type == STDOUT:
+            fd = sys.stdout.fileno()
+        else:
+            # FIXME: Issue #488 - what to do in case fd_type != STDERR?
+            fd = sys.stderr.fileno()
         os.writev(fd, [buffer])
     else:
         if fd_type == STDOUT:
@@ -97,6 +103,7 @@ def __write_raw(fd_info, buffer):
             sys.stderr.write(buffer)
 
 
+# FIXME: Issue #488
 def _logging_handler(fd_info, buffer):
     """
     Log into either STDOUT or to STDERR.

--- a/leapp/libraries/stdlib/call.py
+++ b/leapp/libraries/stdlib/call.py
@@ -45,6 +45,7 @@ def _multiplex(ep, read_fds, callback_raw, callback_linebuffered,
                 hupped.add(fd)
                 ep.unregister(fd)
             if event & (select.EPOLLIN | select.EPOLLPRI) != 0:
+                # FIXME: Issue #488
                 fd_type = read_fds.index(fd) + 1
                 read = os.read(fd, buffer_size)
                 callback_raw((fd, fd_type), read)
@@ -68,6 +69,7 @@ def _multiplex(ep, read_fds, callback_raw, callback_linebuffered,
                     ep.unregister(fd)
 
     # FIXME: (**LINE_BUFFER**)
+    # FIXME: Issue #488
     # # Process leftovers from line buffering
     # for (fd, lb) in linebufs.items():
     #     if lb:
@@ -78,6 +80,7 @@ def _multiplex(ep, read_fds, callback_raw, callback_linebuffered,
     return buf
 
 
+# FIXME: Issue #488
 def _call(command, callback_raw=lambda fd, value: None, callback_linebuffered=lambda fd, value: None,
           encoding='utf-8', poll_timeout=1, read_buffer_size=80, stdin=None):
     """


### PR DESCRIPTION
Now the __write_raw (and run) function should be working with Py2
and Py3 as well, but it is temporary solution as the leapp.stdlib.call
is still in bad shape.

Fixes: #487
Related issue #488