### PR TITLE
stdlib: add option to run() to ignore exit code

### DIFF
--- a/leapp/libraries/stdlib/__init__.py
+++ b/leapp/libraries/stdlib/__init__.py
@@ -119,7 +119,7 @@ def _logging_handler(fd_info, buffer):
         __write_raw(fd_info, buffer)
 
 
-def run(args, split=False, callback_raw=_logging_handler, env=None):
+def run(args, split=False, callback_raw=_logging_handler, env=None, checked=True):
     """
     Run a command and return its result as a dict.
 
@@ -131,6 +131,8 @@ def run(args, split=False, callback_raw=_logging_handler, env=None):
     :type split: bool
     :param callback_raw: Optional custom callback executed on raw data to print in console
     :type callback_raw: (fd: int, buffer: bytes) -> None
+    :param checked: Raise an exception on a non-zero exit code, default True
+    :type checked: bool
     :return: {'stdout' : stdout, 'stderr': stderr, 'signal': signal, 'exit_code': exit_code, 'pid': pid}
     :rtype: dict
     """
@@ -140,7 +142,7 @@ def run(args, split=False, callback_raw=_logging_handler, env=None):
     try:
         create_audit_entry('process-start', {'id': _id, 'parameters': args, 'env': env})
         result = _call(args, callback_raw=callback_raw, env=env)
-        if result['exit_code'] != 0:
+        if checked and result['exit_code'] != 0:
             raise CalledProcessError(
                 message="A Leapp Command Error occurred. ",
                 command=args,

--- a/tests/scripts/test_stdlib.py
+++ b/tests/scripts/test_stdlib.py
@@ -1,6 +1,7 @@
 import os
+import pytest
 
-from leapp.libraries.stdlib import run
+from leapp.libraries.stdlib import CalledProcessError, run
 from leapp.libraries.stdlib.config import is_debug, is_verbose
 
 
@@ -22,6 +23,17 @@ def test_check_multiline_output():
 def test_check_multiline_output_no_split():
     a_command = ['echo', 'This a multi-\nline No Split test!']
     assert run(a_command, split=False)['stdout'] == u'This a multi-\nline No Split test!\n'
+
+
+def test_check_error():
+    a_command = ['false']
+    with pytest.raises(CalledProcessError):
+        run(a_command, checked=True)
+
+
+def test_check_error_no_checked():
+    a_command = ['false']
+    assert run(a_command, checked=False)['exit_code'] == 1
 
 
 def test_is_verbose(monkeypatch):


### PR DESCRIPTION
This will be useful in the chrony check actor (https://github.com/oamg/leapp-repository/pull/139).