### PR TITLE
checkpoints: Load checkpoints ordered by `id`

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -77,7 +77,7 @@ def fetch_last_upgrade_context():
     """
     with get_connection(None) as db:
         cursor = db.execute(
-            "SELECT context, stamp, configuration FROM execution WHERE kind = 'upgrade' ORDER BY stamp DESC LIMIT 1")
+            "SELECT context, stamp, configuration FROM execution WHERE kind = 'upgrade' ORDER BY id DESC LIMIT 1")
         row = cursor.fetchone()
         if row:
             return row[0], json.loads(row[2])
@@ -90,7 +90,7 @@ def fetch_all_upgrade_contexts():
     """
     with get_connection(None) as db:
         cursor = db.execute(
-            "SELECT context, stamp, configuration FROM execution WHERE kind = 'upgrade' ORDER BY stamp DESC")
+            "SELECT context, stamp, configuration FROM execution WHERE kind = 'upgrade' ORDER BY id DESC")
         row = cursor.fetchall()
         if row:
             return row

--- a/leapp/snactor/context.py
+++ b/leapp/snactor/context.py
@@ -14,7 +14,7 @@ def last_snactor_context(connection=None):
     """
     with get_connection(db=connection) as db:
         cursor = db.execute('''
-            SELECT context, stamp FROM execution WHERE kind = 'snactor-run' ORDER BY stamp DESC LIMIT 1
+            SELECT context, stamp FROM execution WHERE kind = 'snactor-run' ORDER BY id DESC LIMIT 1
         ''')
         row = cursor.fetchone()
         if row:

--- a/leapp/utils/audit/__init__.py
+++ b/leapp/utils/audit/__init__.py
@@ -450,7 +450,7 @@ def get_checkpoints(context):
                 data_source ON data_source.id = audit.data_source_id
               WHERE
                 audit.context = ? AND audit.event = ?
-              ORDER BY stamp ASC;
+              ORDER BY audit.id ASC;
         ''', (context, _AUDIT_CHECKPOINT_EVENT))
         cursor.row_factory = _dict_factory
         return cursor.fetchall()


### PR DESCRIPTION
Previously checkpoints were loaded from the audit table in the database
and ordered by timestamp. However we ran into some problems were
timestamps were off due to some misconfiguration that caused the time
of the system being in the past after the reboot.
That resulted in leapp, trying to resume at a place that has been
already executed before.

This patch will change the ordering to use the row id, which is
sequential in SQLite.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>