### PR TITLE
models: Fix warning about memebership check

### DIFF
--- a/leapp/models/__init__.py
+++ b/leapp/models/__init__.py
@@ -80,7 +80,7 @@ class Model(with_metaclass(ModelMeta)):
     """
     def __init__(self, init_method='from_initialization', **kwargs):
         super(Model, self).__init__()
-        defined_fields = type(self).fields
+        defined_fields = type(self).fields or {}
         for key in kwargs.keys():
             if key not in defined_fields:
                 raise ModelMisuseError(


### PR DESCRIPTION
Previously the value 'fields' of a Model could be potentially `None`
which is not usuable for `x in y` kind of checks. This raised a pylint
warning.
This patch fixes this minority.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>