### PR TITLE
Add preupgrade subcommand + refactor config, paths and output colors

### DIFF
--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -26,5 +26,6 @@ def main():
     if report:
         cli.command.add_sub(report.report.command)
     cli.command.add_sub(upgrade.list_runs.command)
+    cli.command.add_sub(upgrade.preupgrade.command)
     cli.command.add_sub(upgrade.upgrade.command)
     cli.command.execute('leapp version {}'.format(VERSION))

--- a/leapp/cli/report/__init__.py
+++ b/leapp/cli/report/__init__.py
@@ -14,8 +14,8 @@ from leapp.cli.upgrade import fetch_last_upgrade_context
 
 
 @command('report', help='Create report for last upgrade execution (default) or specific execution id')
-@command_opt('--id', help='ID of particular run to print report for. See # leapp list-runs for a list of all runs')
-@command_opt('--format', help='Format report using particular renderers. By default: "plaintext"')
+@command_opt('id', help='ID of particular run to print report for. See # leapp list-runs for a list of all runs')
+@command_opt('format', help='Format report using particular renderers. By default: "plaintext"')
 def report(args):
     if os.getuid():
         raise CommandError('This command has to be run under the root user.')

--- a/leapp/config.py
+++ b/leapp/config.py
@@ -9,8 +9,21 @@ from leapp.utils.repository import find_repository_basedir
 
 _LEAPP_CONFIG = None
 _CONFIG_DEFAULTS = {
+    'archive': {
+        'dir': '/var/log/leapp/archive/',
+    },
     'database': {
         'path': '/var/lib/leapp/leapp.db',
+    },
+    'debug': {
+        'dir': '/var/log/leapp/dnf-debugdata/',
+    },
+    'logs': {
+        'dir': '/var/log/leapp/',
+        'files': 'leapp-upgrade.log:leapp-report.txt:dnf-plugin-data.txt',
+    },
+    'report': {
+        'path': '/var/log/leapp/leapp-report.txt',
     },
     'repositories': {
         'repo_path': '.',

--- a/leapp/logger/__init__.py
+++ b/leapp/logger/__init__.py
@@ -5,6 +5,7 @@ import os
 import time
 import sys
 
+from leapp.config import get_config
 from leapp.libraries.stdlib.config import is_debug, is_verbose
 from leapp.utils.audit import Audit
 _logger = None
@@ -74,7 +75,7 @@ def configure_logger(log_file=None):
             logging.StreamHandler().setLevel(logging.ERROR)
 
         if log_file:
-            file_handler = logging.FileHandler(os.path.join('/var/log/leapp/', log_file))
+            file_handler = logging.FileHandler(os.path.join(get_config().get('logs', 'dir'), log_file))
             file_handler.setFormatter(logging.Formatter(fmt=log_format, datefmt=log_date_format))
             file_handler.setLevel(logging.DEBUG)
             logging.getLogger('leapp').addHandler(file_handler)


### PR DESCRIPTION
Co-authored by: Inessa Vasilevskaya <ivasilev@redhat.com>

Breakdown of changes:
- Added `leapp preupgrade`, which stops after Reports phase and displays info about generated report
- Moved all hardcoded paths to leapp config
- Refactored colorized decorative output
- Removed redundant direct writes to stderr
- Removed redundant dashes from option definitions

Thanks to Inessa for a working proof of concept for the preupgrade.