### PR TITLE
fixtures: introduce conftest.py

### DIFF
--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,6 @@
+from helpers import make_repository_dir_fixture
+
+
+# NOTE(ivasilev) Assigning a fixture generated that way to some variable is a necessary prerequisite for it to be
+# discovered by pylint
+repodir_fixture = make_repository_dir_fixture(name='repository_dir', scope='session')

--- a/tests/scripts/helpers.py
+++ b/tests/scripts/helpers.py
@@ -6,7 +6,7 @@ import pytest
 TESTING_REPOSITORY_NAME = 'testing'
 
 
-def make_repository_dir(name, repository_name=TESTING_REPOSITORY_NAME, scope='session'):
+def make_repository_dir_fixture(name, repository_name=TESTING_REPOSITORY_NAME, scope='session'):
     @pytest.fixture(scope=scope, name=name)
     def impl(request, tmpdir_factory):
         old_value = os.environ.get('LEAPP_CONFIG', None)
@@ -23,6 +23,3 @@ def make_repository_dir(name, repository_name=TESTING_REPOSITORY_NAME, scope='se
             os.environ['LEAPP_CONFIG'] = repository.join('.leapp', 'leapp.conf').strpath
             return repository
     return impl
-
-
-repository_dir = make_repository_dir('repository_dir')

--- a/tests/scripts/test_messaging.py
+++ b/tests/scripts/test_messaging.py
@@ -5,7 +5,6 @@ from leapp.models.error_severity import ErrorSeverity
 from leapp.models import ErrorModel
 from leapp.exceptions import CannotConsumeErrorMessages
 
-from helpers import repository_dir  # noqa: F401; pylint: disable=unused-import
 from test_models import UnitTestModel
 from test_tags import TestTag
 

--- a/tests/scripts/test_repository.py
+++ b/tests/scripts/test_repository.py
@@ -4,7 +4,7 @@ from multiprocessing import Process
 import mock
 import pytest
 
-from helpers import make_repository_dir, repository_dir  # noqa: F401; pylint: disable=unused-import
+from helpers import make_repository_dir_fixture
 from leapp.repository.scan import find_and_scan_repositories, scan_repo
 from leapp.snactor.commands.new_actor import cli as new_actor_cmd
 from leapp.snactor.commands.new_tag import cli as new_tag_cmd
@@ -12,8 +12,9 @@ from leapp.snactor.commands.workflow.new import cli as new_workflow_cmd
 from leapp.exceptions import LeappRuntimeError, RepositoryConfigurationError
 
 
-repository_empty_test_repository_dir = make_repository_dir('empty_repository_dir', scope='module')
-repository_test_repository_dir = make_repository_dir('repository_dir', scope='module')
+# override repository_dir fixture generally defined in session scope
+repository_test_repository_dir = make_repository_dir_fixture('repository_dir', scope='module')
+empty_repodir_fixture = make_repository_dir_fixture(name='empty_repository_dir', scope='module')
 
 
 def test_empty_repo(empty_repository_dir):

--- a/tests/scripts/test_repository_actor_definition.py
+++ b/tests/scripts/test_repository_actor_definition.py
@@ -3,7 +3,6 @@ import logging
 import mock
 import pytest
 
-from helpers import repository_dir  # noqa: F401; pylint: disable=unused-import
 from leapp.repository.actor_definition import ActorDefinition, ActorInspectionFailedError, MultipleActorsError
 from leapp.exceptions import UnsupportedDefinitionKindError
 from leapp.repository import DefinitionKind

--- a/tests/scripts/test_snactor.py
+++ b/tests/scripts/test_snactor.py
@@ -4,7 +4,6 @@ from subprocess import check_call, check_output, CalledProcessError, STDOUT
 
 import pytest
 
-from helpers import repository_dir  # noqa: F401; pylint: disable=unused-import
 from leapp.snactor import context
 from leapp.utils import audit
 

--- a/tests/scripts/test_utils_project.py
+++ b/tests/scripts/test_utils_project.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 from helpers import TESTING_REPOSITORY_NAME
-from helpers import repository_dir  # noqa: F401; pylint: disable=unused-import
 from leapp.exceptions import CommandError
 from leapp.utils.repository import requires_repository, to_snake_case, make_class_name, make_name,\
     find_repository_basedir, get_repository_name, get_repository_metadata


### PR DESCRIPTION
Instead of directly importing fixtures in tests
from helpers and adding a noqa/pylint disable
unused-import comment, pytest's fixture
discovery mechanism is utilized.
Noqa comments and imports have been cleaned up.