### PR TITLE
WIP: Ensure non-zero exit code in case of actor runtime errors

### DIFF
--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -6,7 +6,7 @@ import sys
 from leapp.compat import string_types
 from leapp.dialogs import Dialog
 from leapp.exceptions import MissingActorAttributeError, WrongAttributeTypeError, StopActorExecutionError, \
-    StopActorExecution, StandardError
+    StopActorExecution
 from leapp.models import Model
 from leapp.tags import Tag
 from leapp.utils.i18n import install_translation_for_actor

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -301,10 +301,10 @@ class Actor(object):
             self.process(*args)
         except StopActorExecution:
             pass
-        except NameError as err:
-            self.report_error(err.message, ErrorSeverity.FATAL)
         except StopActorExecutionError as err:
             self.report_error(err.message, err.severity, err.details)
+        except Exception as err:
+            self.report_error(err.message, ErrorSeverity.FATAL)
         finally:
             os.environ.pop('LEAPP_CURRENT_ACTOR', None)
 

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -301,7 +301,7 @@ class Actor(object):
             self.process(*args)
         except StopActorExecution:
             pass
-        except LeappRuntimeError as err:
+        except NameError as err:
             self.report_error(err.message, ErrorSeverity.FATAL)
         except StopActorExecutionError as err:
             self.report_error(err.message, err.severity, err.details)

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -6,7 +6,7 @@ import sys
 from leapp.compat import string_types
 from leapp.dialogs import Dialog
 from leapp.exceptions import MissingActorAttributeError, WrongAttributeTypeError, StopActorExecutionError, \
-    StopActorExecution, LeappRuntimeError
+    StopActorExecution, StandardError
 from leapp.models import Model
 from leapp.tags import Tag
 from leapp.utils.i18n import install_translation_for_actor

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -303,7 +303,7 @@ class Actor(object):
             pass
         except StopActorExecutionError as err:
             self.report_error(err.message, err.severity, err.details)
-        except Exception as err:
+        except StandardError as err:
             self.report_error(err.message, ErrorSeverity.FATAL)
         finally:
             os.environ.pop('LEAPP_CURRENT_ACTOR', None)

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -6,7 +6,7 @@ import sys
 from leapp.compat import string_types
 from leapp.dialogs import Dialog
 from leapp.exceptions import MissingActorAttributeError, WrongAttributeTypeError, StopActorExecutionError, \
-    StopActorExecution, LeappRuntimeError
+    StopActorExecution
 from leapp.models import Model
 from leapp.tags import Tag
 from leapp.utils.i18n import install_translation_for_actor
@@ -303,7 +303,7 @@ class Actor(object):
             pass
         except StopActorExecutionError as err:
             self.report_error(err.message, err.severity, err.details)
-        except LeappRuntimeError as err:
+        except StandardError as err:
             self.report_error(err.message, ErrorSeverity.FATAL)
         finally:
             os.environ.pop('LEAPP_CURRENT_ACTOR', None)

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -6,7 +6,7 @@ import sys
 from leapp.compat import string_types
 from leapp.dialogs import Dialog
 from leapp.exceptions import MissingActorAttributeError, WrongAttributeTypeError, StopActorExecutionError, \
-    StopActorExecution
+    StopActorExecution, LeappRuntimeError
 from leapp.models import Model
 from leapp.tags import Tag
 from leapp.utils.i18n import install_translation_for_actor
@@ -301,6 +301,8 @@ class Actor(object):
             self.process(*args)
         except StopActorExecution:
             pass
+        except LeappRuntimeError as err:
+            self.report_error(err.message, ErrorSeverity.FATAL)
         except StopActorExecutionError as err:
             self.report_error(err.message, err.severity, err.details)
         finally:

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -6,7 +6,7 @@ import sys
 from leapp.compat import string_types
 from leapp.dialogs import Dialog
 from leapp.exceptions import MissingActorAttributeError, WrongAttributeTypeError, StopActorExecutionError, \
-    StopActorExecution
+    StopActorExecution, LeappRuntimeError
 from leapp.models import Model
 from leapp.tags import Tag
 from leapp.utils.i18n import install_translation_for_actor
@@ -303,7 +303,7 @@ class Actor(object):
             pass
         except StopActorExecutionError as err:
             self.report_error(err.message, err.severity, err.details)
-        except StandardError as err:
+        except LeappRuntimeError as err:
             self.report_error(err.message, ErrorSeverity.FATAL)
         finally:
             os.environ.pop('LEAPP_CURRENT_ACTOR', None)

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -303,8 +303,9 @@ class Actor(object):
             pass
         except StopActorExecutionError as err:
             self.report_error(err.message, err.severity, err.details)
-        except StandardError as err:
+        except Exception as err:
             self.report_error(err.message, ErrorSeverity.FATAL)
+            raise err
         finally:
             os.environ.pop('LEAPP_CURRENT_ACTOR', None)
 


### PR DESCRIPTION
Right now, when an internal actor error occurs during workflow execution, leapp exits with 0. This PR is meant to change that, currently by catching the exception and adding it to errors.