### PR TITLE
workaround: multiprocessing.util.Finalize patched

### DIFF
--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,2 +1,6 @@
+from leapp.utils.workarounds import apply_workarounds
+
 VERSION = "0.7.0"
 FULL_VERSION = VERSION
+
+apply_workarounds()

--- a/leapp/utils/workarounds/__init__.py
+++ b/leapp/utils/workarounds/__init__.py
@@ -1,0 +1,5 @@
+import leapp.utils.workarounds.mp
+
+
+def apply_workarounds():
+    leapp.utils.workarounds.mp.apply_workaround()

--- a/leapp/utils/workarounds/mp.py
+++ b/leapp/utils/workarounds/mp.py
@@ -1,0 +1,24 @@
+import os
+import multiprocessing.util
+
+
+def apply_workaround():
+    # Implements:
+    # https://github.com/python/cpython/commit/e8a57b98ec8f2b161d4ad68ecc1433c9e3caad57
+    #
+    # Detection of fix: os imported to compare pids, before the fix os has not
+    # been imported
+    if getattr(multiprocessing.util, 'os', None):
+        return
+
+    class FixedFinalize(multiprocessing.util.Finalize):
+        def __init__(self, *args, **kwargs):
+            super(FixedFinalize, self).__init__(*args, **kwargs)
+            self._pid = os.getpid()
+
+        def __call__(self, *args, **kwargs):
+            if self._pid != os.getpid():
+                return None
+            return super(FixedFinalize, self).__call__(*args, **kwargs)
+
+    setattr(multiprocessing.util, 'Finalize', FixedFinalize)

--- a/tests/scripts/test_workarounds_application.py
+++ b/tests/scripts/test_workarounds_application.py
@@ -1,0 +1,32 @@
+from __future__ import print_function
+
+import os
+
+import leapp  # noqa: F401; pylint: disable=unused-import
+
+
+def test_mp_is_patched():
+    from multiprocessing import Process, Manager
+
+    def child_fun(_lst):
+        pid = os.fork()
+        if not pid:
+            os.execvpe('whatever', [], os.environ)
+        else:
+            os.wait()
+
+    m = Manager()
+    lst = m.list()
+
+    p = Process(target=child_fun, args=(lst,))
+    p.start()
+    p.join()
+    if lst:
+        for el in lst:
+            print(el)
+
+
+def test_mp_workaround_applied():
+    from multiprocessing import util
+    if getattr(util, 'os', None) is None:
+        assert util.Finalize.__name__ == 'FixedFinalize'


### PR DESCRIPTION
Multiprocessing in newer versions received a fix that is not present in
the el7 version of python. In that fix the Finalize class verifies that
the callback is supposed to be run in the process that created the
object. This patch adds a workaround to introduce the same behavior.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>