### PR TITLE
Exit non zero on unhandled exceptions and errors

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -163,7 +163,7 @@ def upgrade(args):
 
     report_errors(workflow.errors)
 
-    if workflow.errors:
+    if workflow.failure:
         sys.exit(1)
 
 
@@ -215,7 +215,7 @@ def preupgrade(args):
     messages = fetch_upgrade_report_raw(context, renderers=False)
     with open(report_json, 'w+') as f:
         json.dump({'entries': messages}, f, indent=2)
-    if workflow.errors:
+    if workflow.failure:
         sys.exit(1)
 
 

--- a/leapp/snactor/commands/run.py
+++ b/leapp/snactor/commands/run.py
@@ -42,10 +42,18 @@ def cli(args):
     messaging = InProcessMessaging(stored=args.save_output)
     messaging.load(actor.consumes)
 
+    failure = False
     with beautify_actor_exception():
-        actor(messaging=messaging, logger=actor_logger).run()
+        try:
+            actor(messaging=messaging, logger=actor_logger).run()
+        except BaseException:
+            failure = True
+            raise
 
     report_errors(messaging.errors())
+
+    if failure or messaging.errors():
+        sys.exit(1)
 
     if args.print_output:
         json.dump(messaging.messages(), sys.stdout, indent=2)

--- a/leapp/snactor/commands/workflow/run.py
+++ b/leapp/snactor/commands/workflow/run.py
@@ -61,6 +61,9 @@ def cli(params):
 
         report_errors(instance.errors)
 
+        if instance.failure:
+            sys.exit(1)
+
     @with_snactor_context
     def snactor_context_impl():
         impl(context=os.getenv('LEAPP_EXECUTION_ID'))


### PR DESCRIPTION
Previously on unhandled exceptions non of the applications did return
with a non zero exit code. This patch will introduce changes to the
framework and endpoint scripts to handle the situation and end with a
non zero exit code.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>