### PR TITLE
Release 0.8.0

### DIFF
--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,6 +1,6 @@
 from leapp.utils.workarounds import apply_workarounds
 
-VERSION = "0.7.0"
+VERSION = "0.8.0"
 FULL_VERSION = VERSION
 
 apply_workarounds()

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,4 +1,4 @@
-.TH LEAPP "1" "17/04/2019" "leapp 0.7.0" "User Commands"
+.TH LEAPP "1" "17/04/2019" "leapp 0.8.0" "User Commands"
 .SH NAME
 leapp - command-line interface to for App & OS Modernization Framework Leapp
 .SH SYNOPSIS

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,4 +1,4 @@
-.TH SNACTOR "1" "17/04/2019" "snactor 0.7.0" "User Commands"
+.TH SNACTOR "1" "17/04/2019" "snactor 0.8.0" "User Commands"
 .SH NAME
 snactor - development and repository management tool for App & OS Modernization Framework Leapp
 .SH SYNOPSIS

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -18,7 +18,7 @@
 %endif
 
 Name:       leapp
-Version:    0.7.0
+Version:    0.8.0
 Release:    1%{?dist}
 Summary:    OS & Application modernization framework
 


### PR DESCRIPTION
Packaging
- Fix URL and Source0 in the SPEC file

=====================================================================
Framework
* Fixes
- Add workround patch for the multiprocessing library
- Exit non-zero on unhandled exceptions and errors
- Fix actor library loading, so libs do not have to be imported
  in lexicographical order
- Fix buf with mode inheritance and list field (#203)
- Fix warning about membership check of models when (#503)
- Load checkpoint ordered by `id` instead of timestamp to prevent
  issues with changed timezone (#499)
- Log on the ERROR level by default instead of DEBUG
- Print usage to stderr

* Enhancements
- Add phase name checking to workflow parameters
- Add the fetch_upgrade_report_raw() function to obtain raw report
  data
- Create a dynamic configuration phase that allows creation
  of configuration for repository workflow
- Functionalite getting actor and phase names when working with
  a workflow

=====================================================================
Leapp
* Fixes
- Add checks of arguments for cmdline parameters
- Load checkpoint ordered by `id` instead of timestamp to prevent
  issues with changed timezone (#499)

* Enhancements
- Add JSON report generation
- Add the preupgrade subcommand for the leapp tool that stops
  workflow execution after the Reports phase and display info about
  generated report

=====================================================================
Snactor
* Fixes
- Add a simple logger to snactor discover command to avoid spurious
  output about missing logger
- Add checks of arguments for cmdline parameters
- Exit non-zero on unhandled exceptions and errors
- Load checkpoint ordered by `id` instead of timestamp to prevent
  issues with changed timezone (#499)

=====================================================================
stdlib
* Fixes
- Add checks of arguments for cmdline parameters

* Enhancements
- Log output of commands to logfile (#520)
- stdlib: add option to `run()` to ignore exit code

=====================================================================
Modifications
- introduced conftest.py to utilize fixture mechanism, so fixture
  doesn't have to be imported explicitly in tests.
- refactoring to satisfy linters