### PR TITLE
Stop adding 'process-end' audit entry

### DIFF
--- a/leapp/libraries/stdlib/__init__.py
+++ b/leapp/libraries/stdlib/__init__.py
@@ -182,7 +182,6 @@ def run(args, split=False, callback_raw=_console_logging_handler, callback_lineb
                 'stdout': result['stdout'].splitlines()
             })
     finally:
-        create_audit_entry('process-end', _id)
         create_audit_entry('process-result', {'id': _id, 'parameters': args, 'result': result, 'env': env})
         api.current_logger().debug('External command is finished: [%s]', ' '.join(args))
     return result

--- a/leapp/utils/audit/__init__.py
+++ b/leapp/utils/audit/__init__.py
@@ -261,7 +261,7 @@ def create_audit_entry(event, data, message=None):
     """
     Create an audit entry
 
-    :param event: Type of this event e.g. process-start or process-end but can be anything
+    :param event: Event type identifier
     :param data: Data related to Type of the event, e.g. a command and its arguments
     :param message: An optional message.
     :return:
@@ -283,7 +283,7 @@ def get_audit_entry(event, context):
 
     :param context: The execution context
     :type context: str
-    :param event: Type of this event e.g. process-start or process-end but can be anything
+    :param event: Event type identifier
     :type event: str
     :return: list of dicts with id, time stamp, actor and phase fields
     """

--- a/tests/scripts/test_audit.py
+++ b/tests/scripts/test_audit.py
@@ -258,7 +258,5 @@ def test_audit_command_in_db(monkeypatch):
     assert result['stdout'] in ['travis\n', 'root\n']
     event = 'process-start'
     assert get_audit_entry(event, _CONTEXT_NAME)
-    event = 'process-end'
-    assert get_audit_entry(event, _CONTEXT_NAME)
     event = 'process-result'
     assert get_audit_entry(event, _CONTEXT_NAME)


### PR DESCRIPTION
We already have "process-start" and "process-result" so
we do not need "process-end" as it does not add any
additional value.