### PR TITLE
insight upload: introduced preupgrade --insights

### DIFF
--- a/leapp/config.py
+++ b/leapp/config.py
@@ -25,6 +25,9 @@ _CONFIG_DEFAULTS = {
     },
     'report': {
         'dir': '/var/log/leapp/',
+        'insights': {'username': 'someuser',
+                     'password': 'somepassword',
+                     'server': 'https://insights.api.endpoint'}
     },
     'repositories': {
         'repo_path': '.',


### PR DESCRIPTION
This PR adds an --insights flag to leapp preupgrade
command that, if specified, allows upload of generated
preupgrade report to the insights platform.
For the dev purposes insights server/auth data can be
controlled with LEAPP_INSIGTS_* environment variables.