### PR TITLE
Fix: Undefined Model "ReportReference"

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -16,6 +16,7 @@ from leapp.utils.audit import Execution, get_connection, get_checkpoints
 from leapp.utils.clicmd import command, command_opt
 from leapp.utils.output import report_errors, report_info, beautify_actor_exception
 from leapp.utils.report import fetch_upgrade_report_raw
+import leapp.reporting
 
 
 def archive_logfiles():


### PR DESCRIPTION
We are able to hit the issue only on some machines (not sure why just
on some machines) during the scan of the repository. The issue
happens during the loading workflow modules.

Modified snippet of the err:

    ...leapp.repository.common: Loading workflow modules
    ...leapp.repository.system_upgrade_el7toel8: Loading workflow modules

    Error: Undefined Model "ReportReference"

To fix that, import leapp.reporting inside the leapp.cli.upgrade
module to enure the Report model reference is loaded.