### PR TITLE
Introduce report composability, remove renderers

### DIFF
--- a/leapp/cli/report/__init__.py
+++ b/leapp/cli/report/__init__.py
@@ -15,7 +15,6 @@ from leapp.cli.upgrade import fetch_last_upgrade_context
 
 @command('report', help='Create report for last upgrade execution (default) or specific execution id')
 @command_opt('id', help='ID of particular run to print report for. See # leapp list-runs for a list of all runs')
-@command_opt('format', help='Format report using particular renderers. By default: "plaintext"')
 def report(args):
     if os.getuid():
         raise CommandError('This command has to be run under the root user.')
@@ -27,15 +26,7 @@ def report(args):
             'No previous Leapp upgrade run found. This command can only be run after "leapp upgrade" has been executed'
         )
 
-    # FIXME: add proper default and choices parameters for the format option
-    if args.format not in ('html', 'plaintext'):
-        print('No / not supported renderer provided as --format (available renderers: "html", "plaintext"). '
-              'Defaulting to "plaintext"', file=sys.stdout, end='\n\n')
-        renderer = 'plaintext'
-    else:
-        renderer = args.format
-
-    messages = fetch_upgrade_report_messages(upgrade_id, renderer)
+    messages = fetch_upgrade_report_messages(upgrade_id)
     if not messages:
         raise CommandError('No upgrade report messages found for context {}'.format(upgrade_id))
 

--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -15,7 +15,7 @@ from leapp.repository.scan import find_and_scan_repositories
 from leapp.utils.audit import Execution, get_connection, get_checkpoints
 from leapp.utils.clicmd import command, command_opt
 from leapp.utils.output import report_errors, report_info, beautify_actor_exception
-from leapp.utils.report import fetch_upgrade_report_raw
+from leapp.utils.report import fetch_upgrade_report_messages
 import leapp.reporting
 
 
@@ -213,7 +213,7 @@ def preupgrade(args):
                                             'leapp-report.{}'.format(f)) for f in ['txt', 'json']]
     report_info([report_txt, report_json], fail=workflow.errors)
     # fetch all report messages as a list of dicts
-    messages = fetch_upgrade_report_raw(context, renderers=False)
+    messages = fetch_upgrade_report_messages(context)
     with open(report_json, 'w+') as f:
         json.dump({'entries': messages}, f, indent=2)
     if workflow.failure:

--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -5,102 +5,258 @@ from leapp.topics import ReportTopic
 from leapp.libraries.stdlib.api import produce
 
 
-class Renderers(Model):
-    """
-    Model for describing renderers to be used when presenting reports.
-    """
-
-    topic = ReportTopic
-
-    html = fields.String()
-    """
-    Render report message as html
-    """
-    plaintext = fields.String()
-    """
-    Render report message as plaintext
-    """
-
-
 class Report(Model):
     """
-    Framework model used for reporting and presentation (see "renderers" field) purposes. The report can also carry
-    a special meaning using "flags" field.
+    Framework model used for reporting
     """
 
     __non_inheritable__ = True
 
     topic = ReportTopic
 
-    severity = fields.StringEnum(choices=['low', 'medium', 'high'])
-    """
-    Severity of the report entry
-    """
-
-    title = fields.String()
-    """
-    Title of the report entry
-    """
-
-    detail = fields.JSON()
-    """
-    Detail of the report entry as JSON data
-    """
-
-    renderers = fields.Model(Renderers)
-    """
-    :class:`Renderers` describe how to render this report entry
-    """
-
-    audience = fields.List(fields.StringEnum(choices=['developer', 'sysadmin']))
-    """
-    Who is the main audience of this report entry
-    """
-
-    flags = fields.List(fields.StringEnum(choices=['inhibitor']))
-    """
-    Flags can give a special meaning to each report entry, currently supported flags:
-
-        inhibitor - This report entry will inhibit the upgrade process
-    """
+    report = fields.JSON()
 
 
-def report(title=None, detail=None, renderers=None, audience=None, flags=None, severity=None):
+def _add_to_dict(data, path, value, leaf_list=False):
+    for p in path[:-1]:
+        if p not in data:
+            data[p] = {}
+        data = data[p]
+
+    if leaf_list:
+        data[path[-1]] = data.get(path[-1], []) + [value]
+    else:
+        if path[-1] in data:
+            raise ValueError('Path {} is already taken'.format('.'.join(path)))
+        data[path[-1]] = value
+
+
+class BasePrimitive(object):
     """
-    Create and produce a report entry
+    Report primitive (field) base class for dict targets (implies unique path)
+    """
+    # deepest nested key in resulting report dict
+    name = ''
 
-    For more information about the arguments, please refer to the :class:`Report` model
+    def __init__(self, value=None):
+        if not isinstance(value, str):
+            raise TypeError('Value of "{}" must be a string'.format(self.__class__.__name__))
+        self._value = value
 
-    :param title: Title of the report message
-    :type title: str
-    :param detail: Report message details
-    :type detail: dict
-    :param renderers: Available report entry renderers (e.g. html / plaintext)
-    :type renderers: dict
-    :param audience: Target audience of the report
-    :type audience: list
-    :param flags: Functionality flags (e.g. inhibitor)
-    :type flags: list
-    :param severity: Report severity
-    :type severity: str
+    @property
+    def value(self):
+        """Return report field value"""
+        return self._value
+
+    @property
+    def path(self):
+        """Return report field destination path (nested dict description)"""
+        return (self.name, )
+
+    @property
+    def to_dict(self):
+        return {self.name: self._value}
+
+    def apply(self, report):
+        """Add report entry to the report dict based on provided path"""
+        _add_to_dict(report, self.path, self.value, leaf_list=False)
+
+
+class BaseListPrimitive(BasePrimitive):
+    """
+    Report primitive (field) base class for list targets (we append value to a list)
+    """
+    def apply(self, report):
+        """Add report entry to the report dict based on provided path"""
+        _add_to_dict(report, self.path, self.value, leaf_list=True)
+
+
+class Title(BasePrimitive):
+    """Report title"""
+    name = 'title'
+
+
+class Summary(BasePrimitive):
+    """Report summary"""
+    name = 'summary'
+
+
+class Severity(BasePrimitive):
+    """Report severity"""
+    name = 'severity'
+
+    INFO = 'info'
+    LOW = 'low'
+    MEDIUM = 'medium'
+    HIGH = 'high'
+
+    def __init__(self, value=None):
+        severities = (self.INFO, self.LOW, self.MEDIUM, self.HIGH)
+        if value not in severities:
+            raise ValueError('Severity should be one of: "{}"'.format(' '.join(severities)))
+        self._value = value
+
+
+class Audience(BasePrimitive):
+    """Target audience of the report"""
+    name = 'audience'
+
+    def __init__(self, value=None):
+        if not isinstance(value, str):
+            raise TypeError('Value of "Audience" must be a string')
+        audiences = ('sysadmin', 'developer')
+        if value not in audiences:
+            raise ValueError('Audience should be one of: "{}"'.format(' '.join(audiences)))
+        self._value = value
+
+
+class Flags(BasePrimitive):
+    """Report flags"""
+    name = 'flags'
+
+    INHIBITOR = 'inhibitor'
+    FAILURE = 'failure'
+
+    def __init__(self, value=None):
+        if not isinstance(value, list):
+            raise TypeError('Value of "Flags" must be a list')
+        self._value = value
+
+
+class Tags(BasePrimitive):
+    """Report tags"""
+    name = 'tags'
+
+    class _Value(object):
+        def __init__(self, value):
+            self.value = value
+
+    ACCESSIBILITY = _Value('accessibility')
+    AUTHENTICATION = _Value('authentication')
+    BOOT = _Value('boot')
+    COMMUNICATION = _Value('communication')
+    DRIVERS = _Value('drivers')
+    EMAIL = _Value('email')
+    ENCRYPTION = _Value('encryption')
+    FILESYSTEM = _Value('filesystem')
+    FIREWALL = _Value('firewall')
+    HIGH_AVAILABILITY = _Value('high availability')
+    KERNEL = _Value('kernel')
+    MONITORING = _Value('monitoring')
+    NETWORK = _Value('network')
+    OS_FACTS = _Value('OS facts')
+    REPOSITORY = _Value('repository')
+    SANITY = _Value('sanity')
+    SECURITY = _Value('security')
+    SELINUX = _Value('selinux')
+    SERVICES = _Value('services')
+    TIME_MANAGEMENT = _Value('time management')
+    TOOLS = _Value('tools')
+    UPGRADE_PROCESS = _Value('upgrade process')
+
+    def __init__(self, value=None):
+        if not isinstance(value, list):
+            raise TypeError('Value of "Tags" must be a list')
+        if not all([isinstance(v, Tags._Value) for v in value]):
+            raise TypeError('Unsupported tag value passed for Report Tags.')
+        # after the objects validation we nedd the actual values in the list
+        self._value = [v.value for v in value]
+
+
+class ExternalLink(BaseListPrimitive):
+    """External link report detail field"""
+    name = 'external'
+
+    def __init__(self, url=None, title=None):
+        if not all(isinstance(v, str) for v in (url, title)):
+            raise TypeError('Values "url" and "title" of "ExternalLink" must be a string')
+        self._value = {'url': url, 'title': title}
+
+    @property
+    def path(self):
+        return ('detail', 'external')
+
+
+class RelatedResource(BaseListPrimitive):
+    """Report detail field for related resources (e.g. affected packages/files)"""
+    name = 'related_resources'
+
+    def __init__(self, scheme=None, identifier=None):
+        if not all(isinstance(v, str) for v in (scheme, identifier)):
+            raise TypeError('Values "scheme" and "identifier" of "RelatedResource" must be a string')
+        self._value = {'scheme': scheme, 'title': identifier}
+
+    @property
+    def path(self):
+        return ('detail', 'related_resources')
+
+
+class BaseRemediation(BaseListPrimitive):
+    """Remediation base class"""
+    name = 'remediations'
+
+    @property
+    def path(self):
+        return ('detail', 'remediations')
+
+
+class RemediationCommand(BaseRemediation):
+    def __init__(self, value=None):
+        if not isinstance(value, list):
+            raise TypeError('Value of "RemediationCommand" must be a list')
+        self._value = {'type': 'command', 'context': value}
+
+
+class RemediationHint(BaseRemediation):
+    def __init__(self, value=None):
+        self._value = {'type': 'hint', 'context': value}
+
+
+class RemediationPlaybook(BaseRemediation):
+    def __init__(self, value=None):
+        self._value = {'type': 'playbook', 'context': value}
+
+
+class Remediation(object):
+    def __init__(self, playbook=None, commands=None, hint=None):
+        self._remediations = []
+        if hint:
+            self._remediations.append(RemediationHint(value=hint))
+        if commands:
+            for command in commands:
+                self._remediations.append(RemediationCommand(value=command))
+        if playbook:
+            self._remediations.append(RemediationPlaybook(value=playbook))
+
+    def apply(self, report):
+        for remediation in self._remediations:
+            remediation.apply(report)
+
+    @property
+    def to_dict(self):
+        return {'remediations': [r.to_dict for r in self._remediations]}
+
+
+def _sanitize_entries(entries):
+    if not any(isinstance(e, Title) for e in entries):
+        raise ValueError('Title not provided in the report.')
+    if not any(isinstance(e, Summary) for e in entries):
+        raise ValueError('Summary not provided in the report.')
+    if not any(isinstance(e, Severity) for e in entries):
+        entries.append(Severity('info'))
+    if not any(isinstance(e, Audience) for e in entries):
+        entries.append(Audience('sysadmin'))
+
+
+def create_report(entries):
+    """
+    Create final report message
     """
 
-    # set some healthy defaults
-    audience = audience or ['sysadmin']
-    severity = severity or 'medium'
-    flags = flags or []
+    report = {}
 
-    renderers = Renderers(**renderers)
-    report_entry = {
-        'title': title,
-        'detail': detail,
-        'renderers': renderers,
-        'severity': severity,
-        'flags': flags,
-        'audience': audience,
-    }
+    _sanitize_entries(entries)
+    for entry in entries:
+        entry.apply(report)
 
-    if 'title' in report_entry['detail']:
-        raise ValueError('Key "title" cannot be present in the report "detail" structure')
-
-    produce(Report(**report_entry))
+    produce(Report(report=report))

--- a/leapp/utils/report.py
+++ b/leapp/utils/report.py
@@ -1,72 +1,20 @@
 import json
-import six
-
-from jinja2 import Template
 
 from leapp.utils.audit import get_messages
 
 
-def _flatten_dict(dict_):
-    new_dict = {}
-    if type(dict_) is not dict:
-        return new_dict
-
-    for k, v in six.iteritems(dict_):
-        if type(v) == dict:
-            new_dict.update(_flatten_dict(v))
-        else:
-            new_dict[k] = v
-
-    return new_dict
-
-
-def fetch_upgrade_report_raw(context_id, renderers=True):
+def fetch_upgrade_report_messages(context_id):
     """
     :param context_id: ID to identify the needed messages
     :type context_id: str
-    :param renderers: whether copy or skip renderers field of original message
-    :type boolean
-    :return: A list of upgrade messages of type "Report" withing the given context,
-             each message is a dict of raw data.
+    :return: All upgrade messages of type "Report" withing the given context
     """
     report_msgs = get_messages(names=['Report'], context=context_id) or []
 
     messages = []
     for message in report_msgs:
-        data = json.loads(message.get('message').get('data'))
-        merged_data = {
-            'topic': message.get('topic'),
-            'phase': message.get('phase'),
-            'audience': data['audience'],
-            'title': data['title'],
-            'flags': data['flags'],
-            'severity': data['severity']
-        }
-        if renderers:
-            merged_data['renderers'] = data['renderers']
-        detail = _flatten_dict(json.loads(data['detail']))
-        merged_data.update(detail)
-        messages.append(merged_data)
+        data = message['message']['data']
+        report = json.loads(json.loads(data).get('report'))
+        messages.append(report)
 
     return messages
-
-
-def fetch_upgrade_report_messages(context_id, renderer):
-    """
-    :param context_id: ID to identify the needed messages
-    :type context_id: str
-    :param renderer: How messages will be rendered (e.g html or plaintext)
-    :type renderer: str
-    :return: All upgrade messages of type "Report" withing the given context
-    """
-    messages_raw = fetch_upgrade_report_raw(context_id)
-    if not messages_raw:
-        # return [] to be consistent?
-        return
-
-    messages_to_print = []
-    for msg_data in messages_raw:
-        template = Template(msg_data.pop('renderers').get(renderer))
-        messages_to_print.append(template.render(msg_data))
-
-    return messages_to_print

--- a/tests/scripts/test_reporting.py
+++ b/tests/scripts/test_reporting.py
@@ -1,0 +1,74 @@
+from collections import namedtuple
+
+import pytest
+
+from leapp.reporting import _add_to_dict
+
+
+ReportPrimitive = namedtuple('ReportPrimitive', ['data', 'path', 'value', 'is_leaf_list'])
+
+leaf_is_dict = ReportPrimitive({}, ('summary',), 'We better fix this!', False)
+leaf_is_list = ReportPrimitive({}, ('summary',), 'We better fix this!', False)
+
+path_taken = ReportPrimitive({'summary': 'Fix is coming!'}, ('summary',), 'We better fix this!', False)
+
+leaf_list_append1 = ReportPrimitive(
+    {}, ('detail', 'remediation'), {'type': 'hint', 'context': 'Read the docs!'}, True
+)
+leaf_list_append2 = ReportPrimitive(
+    {}, ('detail', 'remediation'), {'type': 'command', 'context': 'man leapp'}, True
+)
+
+
+def value_from_path(data, path):
+    value = data
+    for p in path:
+        if isinstance(value, dict) and value.get(p, None):
+            value = value[p]
+        else:
+            return None
+    return value
+
+
+def is_path_valid(data, path):
+    return bool(value_from_path(data, path))
+
+
+def assert_leaf_list(data, path, is_leaf_list):
+    res = isinstance(value_from_path(data, path), list)
+    if is_leaf_list:
+        assert res
+    else:
+        assert not res
+
+
+@pytest.mark.parametrize('primitive', (leaf_is_dict, leaf_is_list))
+def test_add_to_dict_func_leaves(primitive):
+    data, path, value, is_leaf_list = primitive
+
+    _add_to_dict(data, path, value, is_leaf_list)
+    assert is_path_valid(data, path)
+    assert_leaf_list(data, path, is_leaf_list)
+
+
+def test_add_to_dict_func_path_taken():
+    data, path, value, is_leaf_list = path_taken
+
+    with pytest.raises(ValueError):
+        _add_to_dict(data, path, value, is_leaf_list)
+
+
+def test_add_to_dict_func_append():
+    data, path, value, is_leaf_list = leaf_list_append1
+
+    _add_to_dict(data, path, value, is_leaf_list)
+    assert is_path_valid(data, path)
+    assert_leaf_list(data, path, is_leaf_list)
+
+    # we do not want data again as we will re-use the dict for appending
+    _data, path, value, is_leaf_list = leaf_list_append2
+    _add_to_dict(data, path, value, is_leaf_list)
+
+    assert is_path_valid(data, path)
+    assert_leaf_list(data, path, is_leaf_list)
+    assert len(value_from_path(data, path)) == 2


### PR DESCRIPTION
    Introduce report composability, remove renderers
    
    In order to easily extend report with more fields and
    change the structure, we switch to using classes
    (primitives) with configurable paths. This commit
    also removes renderers as a standalone html report
    should substitute it.

kudos to @shaded-enmity 