### PR TITLE
Fix display of generated reports

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -209,13 +209,15 @@ def preupgrade(args):
 
     report_errors(workflow.errors)
 
-    report_txt, report_json = [os.path.join(get_config().get('report', 'dir'),
-                                            'leapp-report.{}'.format(f)) for f in ['txt', 'json']]
-    report_info([report_txt, report_json], fail=workflow.errors)
+    cfg = get_config()
+    report_json = os.path.join(cfg.get('report', 'dir'), 'leapp-report.json')
     # fetch all report messages as a list of dicts
     messages = fetch_upgrade_report_raw(context, renderers=False)
     with open(report_json, 'w+') as f:
         json.dump({'entries': messages}, f, indent=2)
+    report_files = [os.path.join(cfg.get('report', 'dir'), r) for r in cfg.get('report', 'files').split(',')]
+    report_info([rf for rf in report_files if os.path.isfile(rf)], fail=workflow.failure)
+
     if workflow.failure:
         sys.exit(1)
 

--- a/leapp/config.py
+++ b/leapp/config.py
@@ -8,6 +8,20 @@ from leapp.utils.repository import find_repository_basedir
 
 
 _LEAPP_CONFIG = None
+# files that will go into the leapp-logs.tar.gz archive and get deleted each time a run is started
+_FILES_TO_ARCHIVE = [
+    'dnf-plugin-data.txt',
+    'leapp-report.json',
+    'leapp-report.txt',
+    'leapp-preupgrade.log',
+    'leapp-upgrade.log',
+]
+# files that will get reported at the end of a preupgrade run if they were created/modified during it
+_FILES_TO_REPORT = [
+    'leapp-report.json',
+    'leapp-report.txt',
+    'leapp-preupgrade.log',
+]
 _CONFIG_DEFAULTS = {
     'archive': {
         'dir': '/var/log/leapp/archive/',
@@ -20,11 +34,11 @@ _CONFIG_DEFAULTS = {
     },
     'logs': {
         'dir': '/var/log/leapp/',
-        # files that will go into the leapp-logs.tar.gz archive
-        'files': 'leapp-upgrade.log,leapp-report.txt,leapp-report.json,dnf-plugin-data.txt',
+        'files': ','.join(_FILES_TO_ARCHIVE),
     },
     'report': {
         'dir': '/var/log/leapp/',
+        'files': ','.join(_FILES_TO_REPORT),
     },
     'repositories': {
         'repo_path': '.',

--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -16,7 +16,7 @@ class Color(object):
 
 
 def pretty_block(string, color=Color.bold, width=60):
-    return "{color}{separator}\n{text}\n{separator}{reset}\n\n".format(
+    return "\n{color}{separator}\n{text}\n{separator}{reset}\n".format(
         color=color,
         separator="=" * width,
         reset=Color.reset,
@@ -35,9 +35,9 @@ def print_error(error):
 def report_errors(errors):
     if errors:
         sys.stdout.write(pretty_block("ERRORS", color=Color.red))
+        sys.stderr.write("\n")
         for error in errors:
             print_error(error)
-        sys.stderr.write("\n")
         sys.stdout.write(pretty_block("END OF ERRORS", color=Color.red))
 
 
@@ -45,8 +45,9 @@ def report_info(path, fail=False):
     paths = [path] if not isinstance(path, list) else path
     if paths:
         sys.stdout.write(pretty_block("REPORT", color=Color.bold if fail else Color.green))
+        sys.stdout.write("\n")
         for report_path in paths:
-            sys.stdout.write("A report has been generated at {path}\n\n".format(path=report_path))
+            sys.stdout.write("A report has been generated at {path}\n".format(path=report_path))
         sys.stdout.write(pretty_block("END OF REPORT", color=Color.bold if fail else Color.green))
 
 


### PR DESCRIPTION
Changes:
- report blocks aren't green in case of thrown exceptions
- only report files generated in the current preupgrade run are displayed
  - currently comparison of modification time with stamp inside workflow's Execution is used
- slight reorder of newlines in output