### PR TITLE
Make leapp show help message for proper subcommand

### DIFF
--- a/leapp/utils/clicmd.py
+++ b/leapp/utils/clicmd.py
@@ -89,7 +89,17 @@ class Command(object):
         else:
             s = parser
         self.apply_parser(s, parser=parser)
-        args = parser.parse_args()
+        # NOTE(ivasilev) a clumsy hack to make leapp output help information for the
+        # exact subcommand that has been called.
+        # The original problem was with parser.parse_args() referring to parser for
+        # topmost leapp command and not the subcommand during error processing.
+        # Any ideas and proposals on a more elegant solution are welcome.
+        args, leftover = parser.parse_known_args()
+        if leftover:
+            cmdname = args.prog.split()[-1]
+            # NOTE(ivasilev) No vetting of cmdname is necessary here as unless a proper leapp subcommand was
+            # invocated parser.parse_known_args() would have thrown an exception
+            self._sub_commands[cmdname].parser.error(leftover)
         args.func(args)
 
     def get_inheritable_options(self):


### PR DESCRIPTION
Before that patch leapp preupgrade --nosuchflag would
show help information for topmost leapp command, not
usage information for leapp preupgrade.
That is a clumsy hack to access help info for the
exact subcommand that has been called.
The original problem was with parser.parse_args()
returning parser for topmost leapp command and not
the subcommand.
Any ideas and proposals on a more elegant solution are
welcome.

Closes-Issue:#550