### PR TITLE
reporting: Add PYTHON tag

### DIFF
--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -145,6 +145,7 @@ class Tags(BasePrimitive):
     MONITORING = _Value('monitoring')
     NETWORK = _Value('network')
     OS_FACTS = _Value('OS facts')
+    PYTHON = _Value('python')
     REPOSITORY = _Value('repository')
     SANITY = _Value('sanity')
     SECURITY = _Value('security')


### PR DESCRIPTION
This tag is required by PythonInformUser actor
which has been erroneously disabled because of
missing workflow tag in actor definition.
Unless this tag is added any preupgrade\upgrade
will fail when the actor definition is fixed.