### PR TITLE
Allow testing actors with config models

### DIFF
--- a/docs/source/unit-testing.md
+++ b/docs/source/unit-testing.md
@@ -77,6 +77,12 @@ def test_actor_execution(current_actor_context):
     assert current_actor_context.consume(ProducedExampleModel)[0].value == 3
 ```
 
+In case your actor uses `ConfigModel` for consuming workflow specific configuration, run the actor in the test as:
+
+```python
+current_actor_context.run(config_model=ConfigModel(os_release=OSRelease()))
+```
+
 #### Fixtures
 
 The unit testing support was first implemented with the help of

--- a/leapp/snactor/fixture.py
+++ b/leapp/snactor/fixture.py
@@ -95,13 +95,21 @@ class ActorContext(object):
         for model in models:
             self._messaging.feed(model, self)
 
-    def run(self):
+    def run(self, config_model=None):
         """
         Execute the current actor.
 
+        :param config_model: Config model for the actor to consume.
+        :type config_model: Config model instance derived from :py:class:`leapp.models.Model`
         :return: None
         """
-        self._actor(messaging=self._messaging).run()
+        config_model_cls = config_model.__class__ if config_model else None
+        if config_model:
+            self._messaging.feed(config_model, self)
+            # we have to make messaging system aware of config model being used as this is normally done by workflow
+            self._messaging._config_models = (config_model_cls,)
+        # the same as above applies here for actor
+        self._actor(messaging=self._messaging, config_model=config_model_cls).run()
 
     def messages(self):
         """


### PR DESCRIPTION
Currently, when tested actor runs and tries to access workflow
config, it fails with WorkflowConfigNotAvailable. Apart from
feeding the actor a mock config model, we need to also make
it aware it should use the config.