### PR TITLE
Dynamic phase skipping support

### DIFF
--- a/leapp/messaging/commands.py
+++ b/leapp/messaging/commands.py
@@ -1,0 +1,14 @@
+class WorkflowCommand(object):
+    def __init__(self, command, arguments):
+        self._command = command
+        self._arguments = arguments
+
+    def encode(self):
+        return {'command': self._command, 'arguments': self._arguments}
+
+
+class SkipPhasesUntilCommand(WorkflowCommand):
+    COMMAND = 'skip_phases_until'
+
+    def __init__(self, until_phase):
+        super(SkipPhasesUntilCommand, self).__init__(self.COMMAND, {'until_phase': until_phase})

--- a/leapp/workflows/__init__.py
+++ b/leapp/workflows/__init__.py
@@ -8,6 +8,7 @@ from leapp.dialogs import RawMessageDialog
 from leapp.exceptions import CommandError, MultipleConfigActorsError, WorkflowConfigNotAvailable
 from leapp.messaging.answerstore import AnswerStore
 from leapp.messaging.inprocess import InProcessMessaging
+from leapp.messaging.commands import SkipPhasesUntilCommand
 from leapp.tags import ExperimentalTag
 from leapp.utils import reboot_system
 from leapp.utils.audit import checkpoint, get_errors
@@ -290,6 +291,12 @@ class Workflow(with_metaclass(WorkflowMeta)):
                             self.log.info('Workflow interrupted due to FailImmediately error policy')
                             early_finish = True
                             break
+
+                    for command in messaging.commands:
+                        if command['command'] == SkipPhasesUntilCommand.COMMAND:
+                            skip_phases_until = command['arguments']['until_phase']
+                            self.log.info('SkipPhasesUntilCommand received. Skipping phases until {}'.format(
+                                skip_phases_until))
 
                     checkpoint(actor=actor.name, phase=phase[0].name, context=context,
                                hostname=os.environ['LEAPP_HOSTNAME'])


### PR DESCRIPTION
This patch introduces support for actors being able to let leapp skip
phases.
Phases can be skipped by an actor using leapp.messaging.commands.SkipPhasesUntilCommand
like this within the process method:
```python
self._messaging.command(SkipPhasesUntilCommand(until_phase='report'))
```

This will make leapp skip phases until it hits the 'report' phase.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>