### PR TITLE
Fix: report msg not generated at the end of run

### DIFF
--- a/leapp/config.py
+++ b/leapp/config.py
@@ -8,20 +8,24 @@ from leapp.utils.repository import find_repository_basedir
 
 
 _LEAPP_CONFIG = None
+
+# files that will get reported at the end of a preupgrade/upgrade run if they were created/modified during it
+_REPORTS = [
+    'leapp-report.json',
+    'leapp-report.txt',
+]
+
+# debug logs that will get reported at the end of a preupgrade/upgrade run if they were created/modified during it
+_LOGS = [
+    'leapp-upgrade.log',
+    'leapp-preupgrade.log'
+]
+
 # files that will go into the leapp-logs.tar.gz archive and get deleted each time a run is started
 _FILES_TO_ARCHIVE = [
     'dnf-plugin-data.txt',
-    'leapp-report.json',
-    'leapp-report.txt',
-    'leapp-preupgrade.log',
-    'leapp-upgrade.log',
-]
-# files that will get reported at the end of a preupgrade run if they were created/modified during it
-_FILES_TO_REPORT = [
-    'leapp-report.json',
-    'leapp-report.txt',
-    'leapp-preupgrade.log',
-]
+] + _REPORTS + _LOGS
+
 _CONFIG_DEFAULTS = {
     'archive': {
         'dir': '/var/log/leapp/archive/',
@@ -32,13 +36,17 @@ _CONFIG_DEFAULTS = {
     'debug': {
         'dir': '/var/log/leapp/dnf-debugdata/',
     },
-    'logs': {
+    'files_to_archive': {
         'dir': '/var/log/leapp/',
         'files': ','.join(_FILES_TO_ARCHIVE),
     },
+    'logs': {
+        'dir': '/var/log/leapp/',
+        'files': ','.join(_LOGS),
+    },
     'report': {
         'dir': '/var/log/leapp/',
-        'files': ','.join(_FILES_TO_REPORT),
+        'files': ','.join(_REPORTS),
         'answerfile': '/var/log/leapp/answerfile',
     },
     'repositories': {

--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -46,14 +46,22 @@ def report_errors(errors):
         sys.stdout.write(pretty_block("END OF ERRORS", color=Color.red))
 
 
-def report_info(path, fail=False):
-    paths = [path] if not isinstance(path, list) else path
-    if paths:
+def report_info(report_paths, log_paths, fail=False):
+    report_paths = [report_paths] if not isinstance(report_paths, list) else report_paths
+    log_paths = [log_paths] if not isinstance(report_paths, list) else log_paths
+
+    if log_paths:
+        sys.stdout.write("\n")
+        for log_path in log_paths:
+            sys.stdout.write("Debug output written to {path}\n".format(path=log_path))
+
+    if report_paths:
         sys.stdout.write(pretty_block("REPORT", color=Color.bold if fail else Color.green))
         sys.stdout.write("\n")
-        for report_path in paths:
+        for report_path in report_paths:
             sys.stdout.write("A report has been generated at {path}\n".format(path=report_path))
         sys.stdout.write(pretty_block("END OF REPORT", color=Color.bold if fail else Color.green))
+        sys.stdout.write("\n")
 
 
 def report_unsupported(devel_vars, experimental):


### PR DESCRIPTION
At the end of "leapp upgrade" run we do not print message
about generated reports, in contrast to "leapp preupgrade"
where we do.