### PR TITLE
Make error messages part of preupgrade report

### DIFF
--- a/leapp/utils/report.py
+++ b/leapp/utils/report.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 
-from leapp.reporting import Remediation
+from leapp.reporting import Remediation, create_report_from_error
 from leapp.utils.audit import get_messages
 
 
@@ -11,7 +11,7 @@ def fetch_upgrade_report_messages(context_id):
     :type context_id: str
     :return: All upgrade messages of type "Report" withing the given context
     """
-    report_msgs = get_messages(names=['Report'], context=context_id) or []
+    report_msgs = get_messages(names=['Report', 'ErrorModel'], context=context_id) or []
 
     messages = []
     for message in report_msgs:
@@ -31,8 +31,11 @@ def fetch_upgrade_report_messages(context_id):
             'actor': message['actor'],
             'id': sha256.hexdigest()
         }
-
-        report = json.loads(json.loads(data).get('report'))
+        data_json = json.loads(data)
+        report = json.loads(data_json.get('report', "{}"))
+        if not report:
+            # transform Error message to Report message
+            report = create_report_from_error(data_json)
         report.update(envelope)
         messages.append(report)
 

--- a/tests/scripts/test_reporting.py
+++ b/tests/scripts/test_reporting.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 
-from leapp.reporting import _add_to_dict
+from leapp.reporting import _add_to_dict, create_report_from_error
 
 
 ReportPrimitive = namedtuple('ReportPrimitive', ['data', 'path', 'value', 'is_leaf_list'])
@@ -72,3 +72,28 @@ def test_add_to_dict_func_append():
     assert is_path_valid(data, path)
     assert_leaf_list(data, path, is_leaf_list)
     assert len(value_from_path(data, path)) == 2
+
+
+def test_convert_from_error_to_report():
+    error_dict_no_details = {
+        'message': 'The system is not registered or subscribed.',
+        'time': '2019-11-19T05:13:04.447562Z',
+        'details': None,
+        'actor': 'verify_check_results',
+        'severity': 'error'}
+    report = create_report_from_error(error_dict_no_details)
+    assert report["severity"] == "high"
+    assert report["title"] == "The system is not registered or subscribed."
+    assert report["audience"] == "sysadmin"
+    assert report["summary"] == ""
+    error_dict_with_details = {
+        'message': 'The system is not registered or subscribed.',
+        'time': '2019-11-19T05:13:04.447562Z',
+        'details': 'Some other info that should go to report summary',
+        'actor': 'verify_check_results',
+        'severity': 'error'}
+    report = create_report_from_error(error_dict_with_details)
+    assert report["severity"] == "high"
+    assert report["title"] == "The system is not registered or subscribed."
+    assert report["audience"] == "sysadmin"
+    assert report["summary"] == "Some other info that should go to report summary"


### PR DESCRIPTION
Previously workflow errors weren't shown in the
preupgrade report. This patch attempts to solve the
issue by introducing naive one way convertion between
ErrorModel and Report during fetch_report_messages
stage at the end of the workflow run. Database won't be
altered, no new objects added after that convertion.

A follow up may be suggested to refactor existing
errors with "steps needed\hints" information into proper
Report messages.

Closes-Bug: #575