### PR TITLE
lint: fix py3 job

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -40,3 +40,6 @@ max-line-length=120
 [DESIGN]
 max-args=11  # 2x + 1 from default
 max-attributes=21  # 4x + 1 from default
+
+[TYPECHECK]
+disable=bad-option-value  # unavoidable as the project requires both py2 and py3

--- a/leapp/dialogs/renderer.py
+++ b/leapp/dialogs/renderer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from getpass import getpass
 import six
 
 
@@ -102,7 +103,6 @@ class CommandlineRenderer(DialogRendererBase):
     CommandlineRenderer implements the handling for commandline user interactions.
     """
     def __init__(self):
-        from getpass import getpass
         self.getpass = getpass
 
     def render(self, dialog):
@@ -265,7 +265,7 @@ class CommandlineRenderer(DialogRendererBase):
                 if not result:
                     dialog.answer(component, tuple(sorted([component.choices[x] for x in selected])))
                     break
-                elif len(result) == 1 and -1 < indices.index(result) < len(component.choices):
+                if len(result) == 1 and -1 < indices.index(result) < len(component.choices):
                     idx = indices.index(result)
                     if idx in selected:
                         selected.remove(idx)
@@ -275,7 +275,7 @@ class CommandlineRenderer(DialogRendererBase):
                 if not result and component.default is not None:
                     dialog.answer(component, component.default)
                     break
-                elif len(result) == 1 and -1 < indices.index(result) < len(component.choices):
+                if len(result) == 1 and -1 < indices.index(result) < len(component.choices):
                     dialog.answer(component, component.choices[indices.index(result)])
                     break
 

--- a/leapp/exceptions.py
+++ b/leapp/exceptions.py
@@ -116,7 +116,7 @@ class StopActorExecutionError(LeappError):
     :py:func:`leapp.actors.Actor.report_error`.
     """
     # import here to break import cycle
-    from leapp.models.error_severity import ErrorSeverity
+    from leapp.models.error_severity import ErrorSeverity  # pylint: disable=import-outside-toplevel
 
     def __init__(self, message, severity=ErrorSeverity.ERROR, details=None):
         """

--- a/leapp/logger/__init__.py
+++ b/leapp/logger/__init__.py
@@ -7,6 +7,7 @@ import time
 
 from leapp.config import get_config
 from leapp.libraries.stdlib.config import is_debug, is_verbose
+from leapp.utils.actorapi import get_actor_api, RequestException
 from leapp.utils.audit import Audit
 
 _logger = None
@@ -17,7 +18,6 @@ class LeappAuditHandler(logging.Handler):
         super(LeappAuditHandler, self).__init__(*args, **kwargs)
         self.use_remote = kwargs.pop('use_remote', False)
         if self.use_remote:
-            from leapp.utils.actorapi import get_actor_api
             self.url = 'leapp://localhost/actors/v1/log'
             self.session = get_actor_api()
 
@@ -45,7 +45,6 @@ class LeappAuditHandler(logging.Handler):
         Audit(**log_data).store()
 
     def _remote_emit(self, log_data):
-        from leapp.utils.actorapi import RequestException
         try:
             self.session.post(self.url, json=log_data, timeout=0.1)
         except RequestException:

--- a/leapp/models/fields/__init__.py
+++ b/leapp/models/fields/__init__.py
@@ -425,7 +425,7 @@ class Model(Field):
         :type help: str
         """
         super(Model, self).__init__(**kwargs)
-        from leapp.models import Model as ModelType
+        from leapp.models import Model as ModelType  # pylint: disable=import-outside-toplevel
         if not isinstance(model_type, type) or not issubclass(model_type, ModelType):
             raise ModelMisuseError("{} must be a type derived from Model".format(model_type))
         self._model_type = model_type

--- a/leapp/repository/__init__.py
+++ b/leapp/repository/__init__.py
@@ -3,9 +3,10 @@ import os
 import pkgutil
 import sys
 
-import leapp.libraries.common # noqa # pylint: disable=unused-import
-import leapp.workflows
 from leapp.exceptions import RepoItemPathDoesNotExistError, UnsupportedDefinitionKindError
+import leapp.libraries.common # noqa # pylint: disable=unused-import
+from leapp.models import resolve_model_references
+import leapp.workflows
 from leapp.repository.definition import DefinitionKind
 from leapp.repository.actor_definition import ActorDefinition
 from leapp.utils.libraryfinder import LeappLibrariesFinder
@@ -129,7 +130,6 @@ class Repository(object):
             self.log.debug("Loading model modules")
             self._load_modules(self.models, 'leapp.models')
             if resolve:
-                from leapp.models import resolve_model_references
                 resolve_model_references()
 
         if not stage or stage is _LoadStage.LIBRARIES:

--- a/leapp/repository/manager.py
+++ b/leapp/repository/manager.py
@@ -1,5 +1,6 @@
 import itertools
 
+from leapp.models import resolve_model_references
 from leapp.repository import _LoadStage
 
 
@@ -99,7 +100,6 @@ class RepositoryManager(object):
             repo.load(resolve=False, stage=_LoadStage.WORKFLOWS)
 
         if resolve:
-            from leapp.models import resolve_model_references
             resolve_model_references()
 
     def dump(self):

--- a/leapp/snactor/commands/discover.py
+++ b/leapp/snactor/commands/discover.py
@@ -111,7 +111,7 @@ def cli(args):
         sys.stderr.write('\n')
         sys.exit(1)
 
-    actors = [actor for actor in repository.actors]
+    actors = repository.actors
     topics = [topic for topic in get_topics() if _is_local(repository, topic, base_dir, all_repos=args.all)]
     models = [model for model in get_models() if _is_local(repository, model, base_dir, all_repos=args.all)]
     tags = [tag for tag in get_tags() if _is_local(repository, tag, base_dir, all_repos=args.all)]

--- a/tests/scripts/test_actor_api.py
+++ b/tests/scripts/test_actor_api.py
@@ -9,6 +9,7 @@ import pytest
 from leapp.actors import Actor, get_actors
 from leapp.libraries.stdlib import api
 from leapp.messaging import BaseMessaging
+from leapp.models import ApiTestConsume, ApiTestProduce
 from leapp.repository.scan import scan_repo
 
 
@@ -73,7 +74,6 @@ def test_actor_api(repository, actor_name):
 def test_actor_messaging_paths(leapp_forked, repository, actor_name):  # noqa; pylint: disable=unused-argument
     messaging = _TestableMessaging()
     with _with_loaded_actor(repository, actor_name, messaging) as (_unused, actor):
-        from leapp.models import ApiTestConsume, ApiTestProduce
         messaging.feed(ApiTestConsume(data='prefilled'), actor)
 
         assert len(list(actor.consume(ApiTestConsume))) == 1

--- a/tests/scripts/test_repository.py
+++ b/tests/scripts/test_repository.py
@@ -5,11 +5,12 @@ import mock
 import pytest
 
 from helpers import make_repository_dir_fixture
+from leapp.exceptions import LeappRuntimeError, RepositoryConfigurationError
 from leapp.repository.scan import find_and_scan_repositories, scan_repo
 from leapp.snactor.commands.new_actor import cli as new_actor_cmd
 from leapp.snactor.commands.new_tag import cli as new_tag_cmd
 from leapp.snactor.commands.workflow.new import cli as new_workflow_cmd
-from leapp.exceptions import LeappRuntimeError, RepositoryConfigurationError
+import leapp.tags
 
 
 # override repository_dir fixture generally defined in session scope
@@ -87,7 +88,6 @@ def test_repo(repository_dir):
             repository = find_and_scan_repositories(repo_path.dirpath().strpath)
             assert repository
             repository.load(resolve=True)
-            import leapp.tags
             assert getattr(leapp.tags, 'TestTag')
             assert repository.lookup_actor('TestActor')
             assert repository.lookup_workflow('TestWorkflow')

--- a/tests/scripts/test_workarounds_application.py
+++ b/tests/scripts/test_workarounds_application.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from multiprocessing import util, Process, Manager
 
 import os
 
@@ -6,7 +7,6 @@ import leapp  # noqa: F401; pylint: disable=unused-import
 
 
 def test_mp_is_patched():
-    from multiprocessing import Process, Manager
 
     def child_fun(_lst):
         pid = os.fork()
@@ -27,6 +27,5 @@ def test_mp_is_patched():
 
 
 def test_mp_workaround_applied():
-    from multiprocessing import util
     if getattr(util, 'os', None) is None:
         assert util.Finalize.__name__ == 'FixedFinalize'


### PR DESCRIPTION
Travis ci py3 check job was failing because of
some violations (supposedly merged in pre-release hassle
when ci wasn't reliable together with py3 check enablement).