### PR TITLE
Introduce skip_dialogs functionality

### DIFF
--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -84,7 +84,7 @@ class Actor(object):
             'dialogs': [d.serialize() for d in self.dialogs],
         }
 
-    def __init__(self, messaging=None, logger=None, config_model=None):
+    def __init__(self, messaging=None, logger=None, config_model=None, skip_dialogs=False):
         self._configuration = None
         """
         Instance a workflow defined configuration model if available.
@@ -96,6 +96,7 @@ class Actor(object):
         install_translation_for_actor(type(self))
         self._messaging = messaging
         self.log = (logger or logging.getLogger('leapp.actors')).getChild(self.name)
+        self.skip_dialogs = skip_dialogs
         """ A configured logger instance for the current actor. """
 
         if config_model:
@@ -108,6 +109,8 @@ class Actor(object):
         :param dialog: Dialog instance to show
         :return: dictionary with the requested answers, None if not a defined dialog
         """
+        if self.skip_dialogs:
+            return {}
         if dialog in type(self).dialogs:
             return self._messaging.request_answers(dialog)
         return None

--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -223,7 +223,7 @@ def preupgrade(args):
     with beautify_actor_exception():
         until_phase = 'ReportsPhase'
         logger.info('Executing workflow until phase: %s', until_phase)
-        workflow.run(context=context, until_phase=until_phase)
+        workflow.run(context=context, until_phase=until_phase, skip_dialogs=True)
 
     cfg = get_config()
     answerfile = args.save_answerfile or cfg.get('report', 'answerfile')

--- a/leapp/repository/actor_definition.py
+++ b/leapp/repository/actor_definition.py
@@ -34,7 +34,7 @@ class ActorCallContext(object):
     Wraps the actor execution into child process.
     """
 
-    def __init__(self, definition, logger, messaging, config_model):
+    def __init__(self, definition, logger, messaging, config_model, skip_dialogs):
         """
         :param definition: Actor definition
         :type definition: :py:class:`leapp.repository.actor_definition.ActorDefinition`
@@ -49,9 +49,10 @@ class ActorCallContext(object):
         self.logger = logger
         self.messaging = messaging
         self.config_model = config_model
+        self.skip_dialogs = skip_dialogs
 
     @staticmethod
-    def _do_run(stdin, logger, messaging, definition, config_model, args, kwargs):
+    def _do_run(stdin, logger, messaging, definition, config_model, skip_dialogs, args, kwargs):
         if stdin is not None:
             try:
                 sys.stdin = os.fdopen(stdin)
@@ -60,7 +61,8 @@ class ActorCallContext(object):
         definition.load()
         with definition.injected_context():
             target_actor = [actor for actor in get_actors() if actor.name == definition.name][0]
-            target_actor(logger=logger, messaging=messaging, config_model=config_model).run(*args, **kwargs)
+            target_actor(logger=logger, messaging=messaging, config_model=config_model,
+                         skip_dialogs=skip_dialogs).run(*args, **kwargs)
 
     def run(self, *args, **kwargs):
         """
@@ -71,7 +73,8 @@ class ActorCallContext(object):
         except UnsupportedOperation:
             stdin = None
         p = Process(target=self._do_run,
-                    args=(stdin, self.logger, self.messaging, self.definition, self.config_model, args, kwargs))
+                    args=(stdin, self.logger, self.messaging, self.definition, self.config_model,
+                          self.skip_dialogs, args, kwargs))
         p.start()
         p.join()
         if p.exitcode != 0:
@@ -174,8 +177,9 @@ class ActorDefinition(object):
                     tag.actors += (self,)
         return self._discovery
 
-    def __call__(self, messaging=None, logger=None, config_model=None):
-        return ActorCallContext(definition=self, messaging=messaging, logger=logger, config_model=config_model)
+    def __call__(self, messaging=None, logger=None, config_model=None, skip_dialogs=False):
+        return ActorCallContext(definition=self, messaging=messaging, logger=logger, config_model=config_model,
+                                skip_dialogs=skip_dialogs)
 
     @property
     def dialogs(self):

--- a/leapp/workflows/__init__.py
+++ b/leapp/workflows/__init__.py
@@ -203,7 +203,7 @@ class Workflow(with_metaclass(WorkflowMeta)):
         if phase:
             return phase in [name for phs in self._phase_actors for name in phase_names(phs)]
 
-    def run(self, context=None, until_phase=None, until_actor=None, skip_phases_until=None):
+    def run(self, context=None, until_phase=None, until_actor=None, skip_phases_until=None, skip_dialogs=False):
         """
         Executes the workflow
 
@@ -276,7 +276,7 @@ class Workflow(with_metaclass(WorkflowMeta)):
                     messaging = InProcessMessaging(config_model=config_model, answer_store=self._answer_store)
                     messaging.load(actor.consumes)
                     instance = actor(logger=current_logger, messaging=messaging,
-                                     config_model=config_model)
+                                     config_model=config_model, skip_dialogs=skip_dialogs)
                     try:
                         instance.run()
                     except BaseException:


### PR DESCRIPTION
In order to make leapp preupgrade non-interactive by
default the workflow and actor being executed need to
be aware of the mode they are processed in (preupgrade or
upgrade workflow) and skip dialogs accordingly.

This is controlled by the skip_dialogs method variable which
if set to False by default and is propagated into every
workflow.run and actor initialization method.

The preupgrade cli command now sets skip_dialogs=True for
workflow.run which makes all dialogs present to be skipped and
answerfile with all options commented out to be generated while
the upgrade command keeps the old behavior allowing questions to
be asked interactively if no option has been chosen and saved in
answerfile.