### PR TITLE
Require 'requests' package during pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     name='leapp',
     version=main_ns['VERSION'],
     packages=find_packages(exclude=EXCLUSION),
-    install_requires=['six'],
+    install_requires=['six', 'requests'],
     entry_points='''
         [console_scripts]
         snactor=leapp.snactor:main


### PR DESCRIPTION
The requests package was missing when running leapp-repository unit tests - leapp framework was being installed by leapp-repository makefile [as a dependency](https://github.com/oamg/leapp-repository/blob/master/requirements.txt#L12), but without this dependency of leapp framework.

That caused an incorrect workaround on the leapp-repository side which will need to be reverted after this PR is merged:
https://github.com/oamg/leapp-repository/pull/410