### PR TITLE
Change verbosity arguments from the base command to the upgrade related commands

### DIFF
--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -7,14 +7,8 @@ from leapp import VERSION
 
 
 @command('')
-@command_opt('debug', is_flag=True, help='Enable debug mode', inherit=True)
-@command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=True)
-def cli(args):
-    os.environ['LEAPP_DEBUG'] = '1' if args.debug else os.environ.get('LEAPP_DEBUG', '0')
-    if os.environ['LEAPP_DEBUG'] == '1' or args.verbose:
-        os.environ['LEAPP_VERBOSE'] = '1'
-    else:
-        os.environ['LEAPP_VERBOSE'] = os.environ.get('LEAPP_VERBOSE', '0')
+def cli(args): # noqa; pylint: disable=unused-argument
+    pass
 
 
 def main():

--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -124,15 +124,28 @@ def warn_if_unsupported(configuration):
         report_unsupported(devel_vars, configuration["whitelist_experimental"])
 
 
+def handle_output_level(args):
+    """
+    Set environment variables following command line arguments.
+    """
+    os.environ['LEAPP_DEBUG'] = '1' if args.debug else os.environ.get('LEAPP_DEBUG', '0')
+    if os.environ['LEAPP_DEBUG'] == '1' or args.verbose:
+        os.environ['LEAPP_VERBOSE'] = '1'
+    else:
+        os.environ['LEAPP_VERBOSE'] = os.environ.get('LEAPP_VERBOSE', '0')
+
+
 @command('upgrade', help='Upgrades the current system to the next available major version.')
 @command_opt('resume', is_flag=True, help='Continue the last execution after it was stopped (e.g. after reboot)')
 @command_opt('reboot', is_flag=True, help='Automatically performs reboot when requested.')
-@command_opt('whitelist-experimental', action='append', metavar='ActorName',
-             help='Enables experimental actors')
+@command_opt('whitelist-experimental', action='append', metavar='ActorName', help='Enables experimental actors')
+@command_opt('load-answerfile', help='Path to load custom answerfile')
+@command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
+@command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
 def upgrade(args):
     if os.getuid():
         raise CommandError('This command has to be run under the root user.')
-
+    handle_output_level(args)
     if args.whitelist_experimental:
         args.whitelist_experimental = list(itertools.chain(*[i.split(',') for i in args.whitelist_experimental]))
         os.environ['LEAPP_EXPERIMENTAL'] = '1'
@@ -198,12 +211,14 @@ def upgrade(args):
 
 
 @command('preupgrade', help='Generate preupgrade report')
-@command_opt('whitelist-experimental', action='append', metavar='ActorName',
-             help='Enables experimental actors')
+@command_opt('whitelist-experimental', action='append', metavar='ActorName', help='Enables experimental actors')
+@command_opt('save-answerfile', help='Path to save custom answerfile')
+@command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
+@command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
 def preupgrade(args):
     if os.getuid():
         raise CommandError('This command has to be run under the root user.')
-
+    handle_output_level(args)
     if args.whitelist_experimental:
         args.whitelist_experimental = list(itertools.chain(*[i.split(',') for i in args.whitelist_experimental]))
         os.environ['LEAPP_EXPERIMENTAL'] = '1'


### PR DESCRIPTION
Change verbosity arguments from the base command to the upgrade related commands

The verbose and debug options it's now only available in commands where make sense to
increase verbosity.

A re-request of https://github.com/oamg/leapp/pull/574 by @alexandrepossebom, since he left.