### PR TITLE
packaging: improve deps, polish spec and fix split of files

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -158,7 +158,14 @@ BuildRequires:  python3-pytest-cov
 %endif
 
 Requires: leapp-framework-dependencies = %{framework_dependencies}
-Provides: leapp-framework = %{framework_version}
+
+# FIXME: avoiding problems with dependencies on virtual capabilities, see:
+#    https://serverfault.com/questions/411444/rpm-set-required-somepackage-0-5-0-and-somepackage-0-6-0
+# Currently, we do not use this rpm, so commenting the provides for now, until
+# we come up with reliable solution. E.g. avoid possibility to install both
+# version of frameworks - for Py2 and Py3 in the same time. Or rename the 
+# capability; e.g.: leapp-framework-py3
+# Provides: leapp-framework = %{framework_version}
 
 %description -n python3-%{name}
 Python 3 leapp framework libraries.

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -237,6 +237,7 @@ rm -f %{buildroot}/%{_bindir}/leapp
 %{_bindir}/leapp
 %dir %{_sharedstatedir}/leapp
 %dir %{_localstatedir}/log/leapp
+%{python2_sitelib}/leapp/cli
 %endif
 
 
@@ -246,6 +247,7 @@ rm -f %{buildroot}/%{_bindir}/leapp
 ##################################################
 %files -n snactor
 %license COPYING
+%{python2_sitelib}/leapp/snactor
 %{_mandir}/man1/snactor.1*
 %{_bindir}/snactor
 
@@ -258,6 +260,9 @@ rm -f %{buildroot}/%{_bindir}/leapp
 %files -n python2-%{name}
 %license COPYING
 %{python2_sitelib}/*
+# this one is related only to leapp tool
+%exclude %{python2_sitelib}/leapp/cli
+%exclude %{python2_sitelib}/leapp/snactor
 
 %endif
 
@@ -269,10 +274,11 @@ rm -f %{buildroot}/%{_bindir}/leapp
 %files -n python3-%{name}
 %license COPYING
 %{python3_sitelib}/*
+#TODO: ignoring leapp and snactor in separate rpms now as we do not provide
+# entrypoints for Py3 in those subpackages anyway
 
 %endif
 
-#FIXME: in case of rename, put those subpkgs under relevant if statement
 %files deps
 # no files here
 

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -5,6 +5,20 @@
 %global debug_package %{nil}
 %global gittag master
 
+# IMPORTANT: this is for the leapp-framework capability (it's not the real
+# version of the leapp). The capability reflects changes in api and whatever
+# functionality important from the point of repository. In case of
+# incompatible changes, bump the major number and zero minor one. Otherwise
+# bump the minor one.
+# This is kind of help for more flexible development of leapp repository,
+# so people do not have to wait for new official release of leapp to ensure
+# it is installed/used the compatible one.
+%global framework_version 1.0
+
+# IMPORTANT: everytime the requirements are changed, increment number by one
+# - same for Provides in deps subpackage
+%global framework_dependencies 3
+
 # Do not build bindings for python3 for RHEL == 7
 %if 0%{?rhel} && 0%{?rhel} == 7
 %define with_python2 1
@@ -33,7 +47,10 @@ Requires: python3-%{name} = %{version}-%{release}
 %else
 Requires: python2-%{name} = %{version}-%{release}
 %endif
-Requires: leapp-repository >= %{version}
+
+# Just ensure the leapp repository will be installed as well. Compatibility
+# should be specified by the leapp-repository itself
+Requires: leapp-repository
 %endif # !fedora
 
 %description
@@ -69,29 +86,23 @@ Summary: %{summary}
 # RHEL 7
 BuildRequires:  python-devel
 BuildRequires:  python-setuptools
-%else
-# else
+%else # rhel <> 7 or fedora
 BuildRequires:  python2-devel
-
-%if 0%{?fedora}
-# Fedora
-BuildRequires:  python2-pytest-cov
-# BuildRequires:  python2-pytest-flake8
-
-%endif
-
 BuildRequires:  python2-setuptools
 
-%endif
+%if 0%{?fedora}
+BuildRequires:  python2-pytest-cov
+# BuildRequires:  python2-pytest-flake8
+%endif # fedora
+%endif # rhel <> 7
 
-# IMPORTANT: everytime the requirements are changed, increment number by one
-# - same for Provides in deps subpackage
-Requires: leapp-framework-dependencies = 3
+Provides: leapp-framework = %{framework_version}
+Requires: leapp-framework-dependencies = %{framework_dependencies}
 
 %description -n python2-%{name}
 Python 2 leapp framework libraries.
 
-%endif
+%endif # with python2
 
 # FIXME:
 # this subpackages should be used by python2-%%{name} - so it makes sense to
@@ -101,7 +112,7 @@ Summary:    Meta-package with system dependencies of %{name} package
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # same for requiremenrs in main package above
-Provides: leapp-framework-dependencies = 3
+Provides: leapp-framework-dependencies = %{framework_dependencies}
 ##################################################
 # Real requirements for the leapp HERE
 ##################################################
@@ -146,12 +157,13 @@ BuildRequires:  python3-setuptools
 BuildRequires:  python3-pytest-cov
 %endif
 
-Requires: leapp-framework-dependencies = 3
+Requires: leapp-framework-dependencies = %{framework_dependencies}
+Provides: leapp-framework = %{framework_version}
 
 %description -n python3-%{name}
 Python 3 leapp framework libraries.
 
-%endif
+%endif # with python3
 
 ##################################################
 # Prep


### PR DESCRIPTION
    Originally we had troubles with dependencies and release processes
    as we have been strict about versions of leapp and repositories,
    specified in the leapp rpm. As well, we would like to ensure that
    currently we will install all rpms when leapp tool is installed.
    
    So we are going to keep dependency on leapp-repository, but
    without a version specification. We are going to left the
    reponsiblity for version check on repositories itself.
    
    As well, python?-leapp rpms will provide new leapp-framework
    capability informing about incompatible changes or new features that
    affects leapp repository (like changes in stdlib). This one will
    be more flexible than official versioning and can be updated per
    PR (see comment in the spec file for more details).
    
    As well, I added several new macros in the SPEC, so there is no need
    to update same values on several places anymore. Just update macros
    in the top of the SPEC.

There is missing solution for Py3 framework. See the comments for more details, and [this](https://serverfault.com/questions/411444/rpm-set-required-somepackage-0-5-0-and-somepackage-0-6-0). I commented out the capability for `python3-leapp` now, so we can resolve it even later.

--------
## Tasks:

- [x] update leapp.spec
- [ ] create documentation
- [x] prepare PR in leapp-repository 