### PR TITLE
leapp answer command for answerfile management

### DIFF
--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -13,7 +13,6 @@ def cli(args): # noqa; pylint: disable=unused-argument
 
 def main():
     os.environ['LEAPP_HOSTNAME'] = socket.getfqdn()
-    cli.command.add_sub(upgrade.list_runs.command)
-    cli.command.add_sub(upgrade.preupgrade.command)
-    cli.command.add_sub(upgrade.upgrade.command)
+    for cmd in [upgrade.list_runs, upgrade.preupgrade, upgrade.upgrade, upgrade.answer]:
+        cli.command.add_sub(cmd.command)
     cli.command.execute('leapp version {}'.format(VERSION))

--- a/leapp/messaging/__init__.py
+++ b/leapp/messaging/__init__.py
@@ -145,7 +145,9 @@ class BaseMessaging(object):
         else:
             # update dialogs with answers from answerfile. That is necessary for proper answerfile generation
             for component, value in userchoices.items():
-                dialog.component_by_key(component).value = value
+                dialog_component = dialog.component_by_key(component)
+                if dialog_component:
+                    dialog_component.value = value
 
     def command(self, command):
         """

--- a/leapp/messaging/answerstore.py
+++ b/leapp/messaging/answerstore.py
@@ -24,6 +24,26 @@ class AnswerStore(object):
         # So don't even bother updating this to some more 'pythonic' coding style
         self._storage[scope] = dialog_scope
 
+    def update(self, answer_file):
+        """
+        Update answerfile with all answers from answerstore that have correspondent sections in the file.
+
+        Returns a list of sections that were not found in original answerfile and thus were not updated.
+        """
+        # NOTE(ivasilev): py2 configparser doesn't have any means to save comments in ini file. Switch to cfgparse?
+        conf = configparser.SafeConfigParser(allow_no_value=True)
+        conf.read(answer_file)
+        not_updated = []
+        for section, answerdict in self._storage.items():
+            for opt, val in answerdict.items():
+                if section in conf.sections():
+                    conf.set(section, opt, val)
+                else:
+                    not_updated.append("{sec}.{opt}={val}".format(sec=section, opt=opt, val=val))
+        with open(answer_file, 'w') as afile:
+            conf.write(afile)
+        return not_updated
+
     def load(self, answer_file):
         """
         Loads an answer file from the given location and updates the loaded data with it.


### PR DESCRIPTION
Introduce a handy alternative to manual answerfile update to ease
the adoption of new preupgrade\answer\upgrade strategy.

This pr reflects only one part of the story - non-interactive
answerfile management. Prior to it the only option for
answerfile manipulation was to update it via some editor of choice;
now it is possible to register user choices for specific dialog options
as a single cli command:

leapp answer --section remove_pam_pkcs11_module_check.confirm=True \
             --section may_not_be_present_section.option=False

Some refactoring to existing cli commands will also be
carried out as part of this patch.