### PR TITLE
Nicen up error detail display

### DIFF
--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import json
 import sys
-from pprint import pformat
 from contextlib import contextmanager
 
 from leapp.models import ErrorModel
@@ -26,11 +25,16 @@ def pretty_block(string, color=Color.bold, width=60):
 
 def print_error(error):
     model = ErrorModel.create(json.loads(error['message']['data']))
-    sys.stdout.write("{red}{time} [{severity}]{reset} Actor: {actor} Message: {message}\n".format(
+    sys.stdout.write("{red}{time} [{severity}]{reset} Actor: {actor}\nMessage: {message}\n".format(
         red=Color.red, reset=Color.reset, severity=model.severity.upper(),
         message=model.message, time=model.time, actor=model.actor))
     if model.details:
-        print('Detail: ' + pformat(json.loads(model.details)))
+        print('Summary: ')
+        details = json.loads(model.details)
+        for detail in details:
+            print('    {k}: {v}'.format(
+                k=detail.capitalize(),
+                v=details[detail].rstrip().replace('\n', '\n' + ' ' * (6 + len(detail)))))
 
 
 def report_errors(errors):


### PR DESCRIPTION
Before:
```
2020-01-10 16:07:29.037287 [ERROR] Actor: scan_subscription_manager_info Message: A subscription-manager command failed to execute
Detail: {u'details': u"Command ['subscription-manager', 'release'] failed with exit code 1.",
 u'hint': u'Please ensure you have a valid RHEL subscription and your network is up.',
 u'stderr': u"This system is not yet registered. Try 'subscription-manager register --help' for more information.\n"}
```

After:
```
2020-01-10 16:09:30.552676 [ERROR] Actor: scan_subscription_manager_info Message: A subscription-manager command failed to execute
Summary: 
    Details: Command ['subscription-manager', 'release'] failed with exit code 1.
    Stderr: This system is not yet registered. Try 'subscription-manager register --help' for more information.
    Hint: Please ensure you have a valid RHEL subscription and your network is up.
```

Perhaps the Actor and Message - or only Message - could be on their own lines but that's just me.