### PR TITLE
enable testing on multiple architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - "2.7"
   - "3.6"
+arch:
+  - amd64
+  - ppc64le
+  - arm64
 env:
 services:
 matrix:


### PR DESCRIPTION
testing on s390x is not included because centos image used doesn't have a build for s390x