### PR TITLE
Add --add flag to the leapp answer

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -290,6 +290,8 @@ def preupgrade(args):
 @command_opt('answerfile', help='Path to an answerfile to update')
 @command_opt('section', action='append', metavar='dialog_sections',
              help='Record answer for specific section in answerfile')
+@command_opt('add', is_flag=True,
+             help='If set sections will be created even if missing in original answerfile')
 def answer(args):
     """A command to manage answerfile. Updates answerfile with userchoices"""
     cfg = get_config()
@@ -307,7 +309,7 @@ def answer(args):
     answerstore.load(answerfile_path)
     for dialog, option, value in sections:
         answerstore.answer(dialog, option, value)
-    not_updated = answerstore.update(answerfile_path)
+    not_updated = answerstore.update(answerfile_path, allow_missing=args.add)
     if not_updated:
         sys.stderr.write("WARNING: Only sections found in original userfile can be updated, ignoring {}\n".format(
             ",".join(not_updated)))

--- a/leapp/messaging/answerstore.py
+++ b/leapp/messaging/answerstore.py
@@ -24,7 +24,7 @@ class AnswerStore(object):
         # So don't even bother updating this to some more 'pythonic' coding style
         self._storage[scope] = dialog_scope
 
-    def update(self, answer_file):
+    def update(self, answer_file, allow_missing=False):
         """
         Update answerfile with all answers from answerstore that have correspondent sections in the file.
 
@@ -36,9 +36,11 @@ class AnswerStore(object):
         not_updated = []
         for section, answerdict in self._storage.items():
             for opt, val in answerdict.items():
-                if section in conf.sections():
+                if section not in conf.sections() and allow_missing:
+                    conf.add_section(section)
+                try:
                     conf.set(section, opt, val)
-                else:
+                except configparser.NoSectionError:
                     not_updated.append("{sec}.{opt}={val}".format(sec=section, opt=opt, val=val))
         with open(answer_file, 'w') as afile:
             conf.write(afile)


### PR DESCRIPTION
Now by invoking leapp answer command with --allow-missing
flag it will be possible to register an option in the
answerfile.
This scenario may be useful for vagrant box setup and
doesn't affect the preupgrade\upgrade in any way.

leapp answer --section nosuchsection.key=value --allow-missing