### PR TITLE
Workflow API support

### DIFF
--- a/leapp/messaging/__init__.py
+++ b/leapp/messaging/__init__.py
@@ -13,6 +13,7 @@ from leapp.messaging.answerstore import AnswerStore
 from leapp.exceptions import CannotConsumeErrorMessages
 from leapp.models import DialogModel, ErrorModel
 from leapp.messaging.commands import WorkflowCommand
+from leapp.utils import get_api_models
 
 
 class BaseMessaging(object):
@@ -241,7 +242,8 @@ class BaseMessaging(object):
         """
         types = tuple((getattr(t, '_resolved', t) for t in types))
         messages = list(self._data) + list(self._new_data)
-        lookup = {model.__name__: model for model in type(actor).consumes + self._config_models}
+        # Needs to use get_api_models to consider all consumes including the one specified by Workflow APIs
+        lookup = {model.__name__: model for model in get_api_models(type(actor), 'consumes') + self._config_models}
         if types:
             filtered = set(requested.__name__ for requested in types)
             messages = [message for message in messages if message['type'] in filtered]

--- a/leapp/repository/__init__.py
+++ b/leapp/repository/__init__.py
@@ -143,6 +143,7 @@ class Repository(object):
             self._extend_environ_paths('LEAPP_COMMON_FILES', self.files)
             self.log.debug("Installing repository provided common libraries loader hook")
             sys.meta_path.append(LeappLibrariesFinder(module_prefix='leapp.libraries.common', paths=self.libraries))
+            sys.meta_path.append(LeappLibrariesFinder(module_prefix='leapp.workflows.api', paths=self.apis))
 
         if not stage or stage is _LoadStage.ACTORS:
             self.log.debug("Running actor discovery")
@@ -188,6 +189,7 @@ class Repository(object):
         return {
             'repo_dir': self._repo_dir,
             'actors': [mapped_actor_data(a.serialize()) for a in self.actors],
+            'apis': [dict([('path', path)]) for path in self.relative_paths(self.apis)],
             'topics': filtered_serialization(get_topics, self.topics),
             'models': filtered_serialization(get_models, self.models),
             'tags': filtered_serialization(get_tags, self.tags),
@@ -213,6 +215,13 @@ class Repository(object):
         :return: Tuple of actors in the repository
         """
         return tuple(self._definitions.get(DefinitionKind.ACTOR, ()))
+
+    @property
+    def apis(self):
+        """
+        :return: Tuple of apis in the repository
+        """
+        return tuple(self._definitions.get(DefinitionKind.API, ()))
 
     @property
     def topics(self):

--- a/leapp/repository/actor_definition.py
+++ b/leapp/repository/actor_definition.py
@@ -135,6 +135,7 @@ class ActorDefinition(object):
             'tags': self.tags,
             'consumes': self.consumes,
             'produces': self.produces,
+            'apis': self.apis,
             'dialogs': [dialog.serialize() for dialog in self.dialogs],
             'tools': self.tools,
             'files': self.files,
@@ -282,6 +283,13 @@ class ActorDefinition(object):
                 os.environ['LEAPP_TOOLS'] = tools_backup
             else:
                 os.environ.pop('LEAPP_TOOLS', None)
+
+    @property
+    def apis(self):
+        """
+        :return: names of APIs used by this actor
+        """
+        return tuple(self.discover()['apis'])
 
     @property
     def directory(self):

--- a/leapp/repository/definition.py
+++ b/leapp/repository/definition.py
@@ -15,6 +15,7 @@ class DefinitionKind(object):
     TOOLS = _Kind('tools')
     FILES = _Kind('files')
     TESTS = _Kind('tests')
+    API = _Kind('api')
 
-    REPO_WHITELIST = (ACTOR, MODEL, TOPIC, TAG, WORKFLOW, TOOLS, LIBRARIES, FILES)
+    REPO_WHITELIST = (ACTOR, API, MODEL, TOPIC, TAG, WORKFLOW, TOOLS, LIBRARIES, FILES)
     ACTOR_WHITELIST = (TOOLS, LIBRARIES, FILES, TESTS)

--- a/leapp/repository/scan.py
+++ b/leapp/repository/scan.py
@@ -90,7 +90,8 @@ def scan(repository, path):
         ('files', scan_files),
         ('libraries', scan_libraries),
         ('tests', scan_tests),
-        ('tools', scan_tools))
+        ('tools', scan_tools),
+        ('apis', scan_apis))
 
     dirs = [e for e in os.listdir(path) if os.path.isdir(os.path.join(path, e))]
     for name, task in scan_tasks:
@@ -251,3 +252,18 @@ def scan_tests(repo, path, repo_path):
     """
     if os.listdir(path):
         repo.add(DefinitionKind.TESTS, os.path.relpath(path, repo_path))
+
+
+def scan_apis(repo, path, repo_path):
+    """
+    Scans apis and adds them to the repository.
+
+    :param repo: Instance of the repository
+    :type repo: :py:class:`leapp.repository.Repository`
+    :param path: path to the apis
+    :type path: str
+    :param repo_path: path to the repository
+    :type repo_path: str
+    """
+    if os.listdir(path):
+        repo.add(DefinitionKind.API, os.path.relpath(path, repo_path))

--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -44,6 +44,11 @@ def _load_commands_from(path):
 def cli(args):
     if args.logger_config and os.path.isfile(args.logger_config):
         os.environ['LEAPP_LOGGER_CONFIG'] = args.logger_config
+    # Consider using the in repository $REPOPATH/.leapp/logger.conf to actually obey --debug / --verbose
+    # If /etc/leapp/logger.conf or $REPOPATH/.leapp/logger.conf don't exist logging won't work in snactor.
+    elif find_repository_basedir('.') and os.path.isfile(os.path.join(find_repository_basedir('.'),
+                                                                      '.leapp/logger.conf')):
+        os.environ['LEAPP_LOGGER_CONFIG'] = os.path.join(find_repository_basedir('.'), '.leapp/logger.conf')
 
     config_file_path = None
     if args.config and os.path.isfile(args.config):

--- a/leapp/snactor/commands/discover.py
+++ b/leapp/snactor/commands/discover.py
@@ -40,8 +40,9 @@ def _get_actor_path(actor, repository_relative=True):
 
 def _get_actor_details(actor):
     meta = actor.discover()
-    meta['produces'] = tuple(model.__name__ for model in meta['produces'])
-    meta['consumes'] = tuple(model.__name__ for model in meta['consumes'])
+    meta['produces'] = tuple(model.__name__ for model in actor.produces)
+    meta['consumes'] = tuple(model.__name__ for model in actor.consumes)
+    meta['apis'] = tuple(api.serialize() for api in actor.apis)
     meta['tags'] = tuple(tag.name for tag in meta['tags'])
     meta['path'] = _get_class_file(actor)
     meta['dialogs'] = [dialog.serialize() for dialog in actor.dialogs]

--- a/leapp/utils/__init__.py
+++ b/leapp/utils/__init__.py
@@ -3,3 +3,21 @@ import subprocess
 
 def reboot_system():
     subprocess.Popen(['/sbin/shutdown', '-r', 'now'])
+
+
+def get_api_models(actor, what):
+    """
+    Used to retrieve the full list of models including the ones defined by WorkflowAPIs used by the actor.
+
+    :param what: A string which either is 'consumes' or 'produces'
+    :type what: str
+    :param actor: Actor type/instance or ActorDefinition instance to retrieve the information from
+    :type actor: Actor or ActorDefinition
+    :return: Tuple of all produced or consumed models as specified by actor and APIs used by the actor.
+    """
+    def _do_get(api):
+        result = getattr(api, what, ())
+        for a in api.apis or ():
+            result = result + _do_get(a)
+        return result
+    return tuple(set(_do_get(actor)))

--- a/leapp/workflows/api/__init__.py
+++ b/leapp/workflows/api/__init__.py
@@ -1,0 +1,17 @@
+class WorkflowAPI(object):
+    produces = ()
+    consumes = ()
+    apis = ()
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def serialize(cls):
+        return {
+            'name': cls.__name__,
+            'module': cls.__module__,
+            'consumes': [model.__name__ for model in cls.consumes],
+            'produces': [model.__name__ for model in cls.produces],
+            'apis': [api.__name__ for api in cls.apis]
+        }

--- a/tests/data/workflow-api-tests/.leapp/info
+++ b/tests/data/workflow-api-tests/.leapp/info
@@ -1,0 +1,1 @@
+{"name": "workflow-api-tests", "id": "e8bfeffe-9131-4792-bcc3-760628e0fc4b"}

--- a/tests/data/workflow-api-tests/.leapp/leapp.conf
+++ b/tests/data/workflow-api-tests/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${repository:root_dir}
+
+[database]
+path=${repository:state_dir}/leapp.db

--- a/tests/data/workflow-api-tests/.leapp/logger.conf
+++ b/tests/data/workflow-api-tests/.leapp/logger.conf
@@ -1,0 +1,33 @@
+[loggers]
+keys=urllib3,root
+
+[formatters]
+keys=leapp
+
+[handlers]
+keys=leapp_audit,stream
+
+[formatter_leapp]
+format=%(asctime)s.%(msecs)-3d %(levelname)-8s PID: %(process)d %(name)s: %(message)s
+datefmt=%Y-%m-%d %H:%M:%S
+class=logging.Formatter
+
+[logger_urllib3]
+level=WARN
+qualname=urllib3
+handlers=stream
+
+[logger_root]
+level=DEBUG
+handlers=leapp_audit,stream
+
+[handler_leapp_audit]
+class=leapp.logger.LeappAuditHandler
+formatter=leapp
+args=()
+
+[handler_stream]
+class=StreamHandler
+level=ERROR
+formatter=leapp
+args=(sys.stderr,)

--- a/tests/data/workflow-api-tests/actors/apiv1test/actor.py
+++ b/tests/data/workflow-api-tests/actors/apiv1test/actor.py
@@ -1,0 +1,30 @@
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.tags import FirstPhaseTag, WorkflowApiTestWorkflowTag
+from leapp.workflows.api.v1 import TestAPI
+
+
+class ApiV1Test(Actor):
+    """
+    This actor will check that the testing API ApiV3Test is behaving as expected.
+    """
+
+    name = 'api_v1_test'
+    consumes = ()
+    produces = ()
+    apis = (TestAPI,)
+    tags = (FirstPhaseTag, WorkflowApiTestWorkflowTag)
+
+    def process(self):
+        api = TestAPI()
+        # Expected output is always the order a, b, c
+        # The parameter order here also is however a, b, c
+        if api.order_change(1, 2, 3) != (1, 2, 3):
+            raise StopActorExecutionError("order change API failure")
+
+        # Expected is that the input is prefixed with 'survivor.v3.'
+        if api.survivor("APIV1Test") != "survivor.v3.APIV1Test":
+            raise StopActorExecutionError("v1 survivor test failure")
+
+        # Ensure removed is available and works (Doesn't really do anything just ensures not to have an exception)
+        api.removed("ApiV1Test calls removed method")

--- a/tests/data/workflow-api-tests/actors/apiv2test/actor.py
+++ b/tests/data/workflow-api-tests/actors/apiv2test/actor.py
@@ -1,0 +1,26 @@
+from leapp.actors import Actor
+from leapp.tags import FirstPhaseTag, WorkflowApiTestWorkflowTag
+from leapp.workflows.api.v2 import TestAPI
+
+
+class ApiV2Test(Actor):
+    """
+    This actor will check that the testing API ApiV3Test is behaving as expected.
+    """
+
+    name = 'api_v2_test'
+    consumes = ()
+    produces = ()
+    apis = (TestAPI,)
+    tags = (FirstPhaseTag, WorkflowApiTestWorkflowTag)
+
+    def process(self):
+        api = TestAPI()
+        # Expected output is always the order a, b, c
+        # The parameter order here is however c, b, a
+        if api.order_change(3, 2, 1) != (1, 2, 3):
+            raise StopActorExecutionError("order change API failure")
+
+        # Expected is that the input is prefixed with 'survivor.v3.'
+        if api.survivor("APIV2Test") != "survivor.v3.APIV2Test":
+            raise StopActorExecutionError("v2 survivor test failure")

--- a/tests/data/workflow-api-tests/actors/apiv3test/actor.py
+++ b/tests/data/workflow-api-tests/actors/apiv3test/actor.py
@@ -1,0 +1,27 @@
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.tags import FirstPhaseTag, WorkflowApiTestWorkflowTag
+from leapp.workflows.api.v3 import TestAPI
+
+
+class ApiV3Test(Actor):
+    """
+    This actor will check that the testing API ApiV3Test is behaving as expected.
+    """
+
+    name = 'api_v3_test'
+    consumes = ()
+    produces = ()
+    apis = (TestAPI,)
+    tags = (FirstPhaseTag, WorkflowApiTestWorkflowTag)
+
+    def process(self):
+        api = TestAPI()
+        # Expected output is always the order a, b, c
+        # The parameter order here is however b, c, a
+        if api.order_change(2, 3, 1) != (1, 2, 3):
+            raise StopActorExecutionError("order change API failure")
+
+        # Expected is that the input is prefixed with 'survivor.v3.'
+        if api.survivor("APIV3Test") != "survivor.v3.APIV3Test":
+            raise StopActorExecutionError("v3 survivor test failure")

--- a/tests/data/workflow-api-tests/actors/depcheck/actor.py
+++ b/tests/data/workflow-api-tests/actors/depcheck/actor.py
@@ -1,0 +1,47 @@
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.tags import FirstPhaseTag, WorkflowApiTestWorkflowTag
+from leapp.workflows.api.v3 import DepCheckAPI1, DepCheckAPI2, DepCheckAPI3, DepCheckAPI4
+
+
+class DepCheck(Actor):
+    """
+    This actor verifies the Depedencies APIs to be working as intended.
+
+    DepCheckAPI1 and DepCheckAPI3 consume DepCheck1 and DepCheck3 messages.
+    DepCheckAPI2 and DepCheckAPI4 produce DepCheck2 and DepCheck4 messages.
+
+    DepCheckAPI4 requires DepCheckAPI3
+    DepCheckAPI3 requires DepCheckAPI2
+    DepCheckAPI2 requires DepCheckAPI1
+
+    Therefore by requiring DepCheckAPI4 automatically all 4 DepCheckAPI variants
+    are used to amend the consumes and produces fields of the actor.
+
+    Please Note: This is purely a test to ensure that this is the case.
+    I highly recommend instead of relying on the dependencies, that each actor
+    exactly writes what APIs it uses.
+    """
+
+    name = 'dep_check'
+    consumes = ()
+    produces = ()
+    apis = (DepCheckAPI4,)  # A no no normally, be explicit what you use, however for this test it's necessary
+    tags = (FirstPhaseTag, WorkflowApiTestWorkflowTag)
+
+    def process(self):
+        api1 = DepCheckAPI1()
+        if len(api1.consume()) != 1:
+            raise StopActorExecutionError(
+                "Expected 1 result from DepCheckAPI1.consume => {}".format(len(api1.consume())))
+
+        api2 = DepCheckAPI2()
+        api2.produce()
+
+        api3 = DepCheckAPI3()
+        if len(api3.consume()) != 2:
+            raise StopActorExecutionError(
+                "Expected 2 results from DepCheckAPI3.consume => {}".format(len(api3.consume())))
+
+        api4 = DepCheckAPI4()
+        api4.produce()

--- a/tests/data/workflow-api-tests/actors/depcheckconsumes/actor.py
+++ b/tests/data/workflow-api-tests/actors/depcheckconsumes/actor.py
@@ -1,0 +1,26 @@
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.models import DepCheck2, DepCheck4
+from leapp.tags import FirstPhaseTag, WorkflowApiTestWorkflowTag
+
+
+class DepCheckConsumes(Actor):
+    """
+    This actor consumes the Models DepCheck2 and DepCheck4 produced by the DepCheck actor to verify the functionality.
+    """
+
+    name = 'dep_check_consumes'
+    produces = ()
+    consumes = (DepCheck2, DepCheck4)
+    tags = (FirstPhaseTag, WorkflowApiTestWorkflowTag)
+
+    def process(self):
+        # Only one message is supposed to be produced
+        if len(list(self.consume(DepCheck2))) != 1:
+            raise StopActorExecutionError(
+                "Expected 1 DepCheck2 message => {}".format(len(list(self.consume(DepCheck2)))))
+
+        # Only one message is supposed to be produced
+        if len(list(self.consume(DepCheck4))) != 1:
+            raise StopActorExecutionError(
+                "Expected 1 DepCheck4 message => {}".format(len(list(self.consume(DepCheck4)))))

--- a/tests/data/workflow-api-tests/actors/depcheckproduces/actor.py
+++ b/tests/data/workflow-api-tests/actors/depcheckproduces/actor.py
@@ -1,0 +1,17 @@
+from leapp.actors import Actor
+from leapp.models import DepCheck3, DepCheck1
+from leapp.tags import FirstPhaseTag, WorkflowApiTestWorkflowTag
+
+
+class DepCheckProduces(Actor):
+    """
+    Produces messages DepCheck1 and DepCheck3 which are going to be consumed by the DepCheckAPI1 and DepCheckAPI3 APIs.
+    """
+
+    name = 'dep_check_produces'
+    consumes = ()
+    produces = (DepCheck1, DepCheck3)
+    tags = (FirstPhaseTag, WorkflowApiTestWorkflowTag)
+
+    def process(self):
+        self.produce(DepCheck1(), DepCheck3())

--- a/tests/data/workflow-api-tests/actors/secondphaseactor/actor.py
+++ b/tests/data/workflow-api-tests/actors/secondphaseactor/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.tags import SecondPhaseTag, WorkflowApiTestWorkflowTag
+from leapp.workflows.api.v3 import DepCheckAPI4
+
+
+class SecondPhaseActor(Actor):
+    """
+    This is just an actor to ensure no inpact on actors in different phases. Nothing to do for it here.
+    """
+
+    name = 'second_phase_actor'
+    consumes = ()
+    produces = ()
+    apis = (DepCheckAPI4,)
+    tags = (SecondPhaseTag, WorkflowApiTestWorkflowTag)
+
+    def process(self):
+        pass

--- a/tests/data/workflow-api-tests/apis/v1/__init__.py
+++ b/tests/data/workflow-api-tests/apis/v1/__init__.py
@@ -1,0 +1,2 @@
+from leapp.workflows.api.v1.testapi import TestAPI
+from leapp.workflows.api.v1.depcheck import DepCheckAPI1, DepCheckAPI2, DepCheckAPI3, DepCheckAPI4

--- a/tests/data/workflow-api-tests/apis/v1/depcheck.py
+++ b/tests/data/workflow-api-tests/apis/v1/depcheck.py
@@ -1,0 +1,57 @@
+"""
+This module implements some testing APIs for API depdency checks. Ensuring that all consumes and produces are still in
+place and the code keeps working as expected.
+
+DepCheckAPI4 depends on DepCheckAPI3
+DepCheckAPI3 depends on DepCheckAPI2
+DepCheckAPI2 depends on DepCheckAPI1
+
+DepCheckAPI4 Produces: DepCheck4 Inherits: Produces: DepCheck2, Consumes DepCheck1, DepCheck3
+   |
+   L> DepCheckAPI3 Consumes: DepCheck3 Inherits: Produces: DepCheck2, Consumes DepCheck1
+         |
+         L> DepCheckAPI2 Produces: DepCheck2 Inherits: Consumes DepCheck1
+               |
+               L> DepCheckAPI1 Consumes: DepCheck1
+
+"""
+
+from leapp.libraries.stdlib import api
+from leapp.workflows.api import WorkflowAPI
+from leapp.models import DepCheck1, DepCheck2, DepCheck3, DepCheck4
+
+
+class DepCheckAPI1(WorkflowAPI):
+    consumes = (DepCheck1,)
+
+    def consume(self):
+        """ Consumes all DepCheck1 messages and returns them as a list """
+        return list(api.consume(DepCheck1))
+
+
+class DepCheckAPI2(WorkflowAPI):
+    apis = (DepCheckAPI1,)
+    produces = (DepCheck2,)
+
+    def produce(self):
+        """ Produces a DepCheck2 message """
+        api.produce(DepCheck2())
+
+
+class DepCheckAPI3(WorkflowAPI):
+    apis = (DepCheckAPI2,)
+    # Be explicit about what you consume even though DepCheckAPI1 consumes it already and is a dependency
+    consumes = (DepCheck1, DepCheck3)
+
+    def consume(self):
+        """ Consumes all DepCheck3 messages and returns them as a list """
+        return list(api.consume(DepCheck1, DepCheck3))
+
+
+class DepCheckAPI4(WorkflowAPI):
+    apis = (DepCheckAPI3,)
+    produces = (DepCheck4,)
+
+    def produce(self):
+        """ Produces a DepCheck4 message """
+        api.produce(DepCheck4())

--- a/tests/data/workflow-api-tests/apis/v1/testapi.py
+++ b/tests/data/workflow-api-tests/apis/v1/testapi.py
@@ -1,0 +1,37 @@
+from leapp.workflows.api import WorkflowAPI
+from leapp.workflows.api import v2
+
+
+class TestAPI(WorkflowAPI):
+    """
+    V1 of the TestAPI it also depends on the v2.TestAPI
+    """
+    apis = (v2.TestAPI,)
+
+    def __init__(self):
+        # v2 API instance
+        self._impl = v2.TestAPI()
+
+    def order_change(self, a, b, c):
+        """
+        Returns a tuple in the form of a, b, c
+        """
+        print("v1.TestAPI.order_change => " + str((a, b, c)))
+        # Calls v2 api implementation with the corrected parameter order
+        # which then calls the v3 api with the corrected parameter order
+        # returning the value received
+        return self._impl.order_change(c, b, a)
+
+    def survivor(self, value):
+        """
+        Prefixes a given value - Passed through to the latest version
+        """
+        print("v1.TestAPI.survivor")
+        # Calls v2 api implementation which then calls the v3 api
+        # returning the value received
+        return self._impl.survivor(message=value)
+
+    def removed(self, yadda):
+        print("v1.TestAPI.removed('{}')".format(yadda))
+        print("I am removed in newer versions")
+        # Does not really do anything as it is removed in v2 and higher

--- a/tests/data/workflow-api-tests/apis/v2/__init__.py
+++ b/tests/data/workflow-api-tests/apis/v2/__init__.py
@@ -1,0 +1,3 @@
+from leapp.workflows.api.v2.testapi import TestAPI
+from leapp.workflows.api.v1.depcheck import DepCheckAPI1, DepCheckAPI2, DepCheckAPI3, DepCheckAPI4
+from leapp.workflows.api.v2.newapi import NewAPI

--- a/tests/data/workflow-api-tests/apis/v2/newapi.py
+++ b/tests/data/workflow-api-tests/apis/v2/newapi.py
@@ -1,0 +1,5 @@
+from leapp.workflows.api import WorkflowAPI
+
+class NewAPI(WorkflowAPI):
+    def fun(self):
+        return 'NewAPI.fun'

--- a/tests/data/workflow-api-tests/apis/v2/testapi.py
+++ b/tests/data/workflow-api-tests/apis/v2/testapi.py
@@ -1,0 +1,27 @@
+from leapp.workflows.api import WorkflowAPI
+from leapp.workflows.api import v3
+
+
+class TestAPI(WorkflowAPI):
+    """ Implementation of the v2.TestAPI which depends on the v3.TestAPI implementation """
+    apis = (v3.TestAPI,)
+
+    def __init__(self):
+        # Instance of the v3 API
+        self._impl = v3.TestAPI()
+
+    def order_change(self, c, b, a):
+        """
+        Returns the value of a, b, c as a tuple as implemented in the v3 API
+        """
+        print("v2.TestAPI.order_change => " + str((a, b, c)))
+        # Adjusts the order of parameters based on the V3 api needs and returns the value
+        return self._impl.order_change(b, c, a)
+
+    def survivor(self, message):
+        """
+        Prefixes message and returns it.
+        """
+        print("v2.TestAPI.survivor")
+        # Calls the v3 implementation and returns the value
+        return self._impl.survivor(message)

--- a/tests/data/workflow-api-tests/apis/v3/__init__.py
+++ b/tests/data/workflow-api-tests/apis/v3/__init__.py
@@ -1,0 +1,4 @@
+from leapp.workflows.api.v3.testapi import TestAPI
+from leapp.workflows.api.v2.newapi import NewAPI
+from leapp.workflows.api.v1.depcheck import DepCheckAPI1, DepCheckAPI2, DepCheckAPI3, DepCheckAPI4
+

--- a/tests/data/workflow-api-tests/apis/v3/testapi.py
+++ b/tests/data/workflow-api-tests/apis/v3/testapi.py
@@ -1,0 +1,19 @@
+from leapp.workflows.api import WorkflowAPI
+
+
+class TestAPI(WorkflowAPI):
+    """
+    V3 implementation of the TestAPI
+    """
+
+    def order_change(self, b, c, a):
+        """ 'Latest implementation' of the api """
+        print("v3.TestAPI.order_change => " + str((a, b, c)))
+        # Returns a, b, c as promised
+        return a, b, c
+
+    def survivor(self, value):
+        """ The actual prefixing implementation """
+        print("v3.TestAPI.survivor")
+        # Prefixes the value and returns it
+        return "survivor.v3." + value

--- a/tests/data/workflow-api-tests/models/depcheck1.py
+++ b/tests/data/workflow-api-tests/models/depcheck1.py
@@ -1,0 +1,7 @@
+from leapp.models import Model, fields
+from leapp.topics import WorkflowApiTopic
+
+
+class DepCheck1(Model):
+    """ Empty model for test purposes """
+    topic = WorkflowApiTopic

--- a/tests/data/workflow-api-tests/models/depcheck2.py
+++ b/tests/data/workflow-api-tests/models/depcheck2.py
@@ -1,0 +1,7 @@
+from leapp.models import Model, fields
+from leapp.topics import WorkflowApiTopic
+
+
+class DepCheck2(Model):
+    """ Empty model for test purposes """
+    topic = WorkflowApiTopic

--- a/tests/data/workflow-api-tests/models/depcheck3.py
+++ b/tests/data/workflow-api-tests/models/depcheck3.py
@@ -1,0 +1,7 @@
+from leapp.models import Model, fields
+from leapp.topics import WorkflowApiTopic
+
+
+class DepCheck3(Model):
+    """ Empty model for test purposes """
+    topic = WorkflowApiTopic

--- a/tests/data/workflow-api-tests/models/depcheck4.py
+++ b/tests/data/workflow-api-tests/models/depcheck4.py
@@ -1,0 +1,7 @@
+from leapp.models import Model, fields
+from leapp.topics import WorkflowApiTopic
+
+
+class DepCheck4(Model):
+    """ Empty model for test purposes """
+    topic = WorkflowApiTopic

--- a/tests/data/workflow-api-tests/tags/firstphase.py
+++ b/tests/data/workflow-api-tests/tags/firstphase.py
@@ -1,0 +1,5 @@
+from leapp.tags import Tag
+
+
+class FirstPhaseTag(Tag):
+    name = 'first_phase'

--- a/tests/data/workflow-api-tests/tags/secondphase.py
+++ b/tests/data/workflow-api-tests/tags/secondphase.py
@@ -1,0 +1,5 @@
+from leapp.tags import Tag
+
+
+class SecondPhaseTag(Tag):
+    name = 'second_phase'

--- a/tests/data/workflow-api-tests/tags/workflowapitestworkflow.py
+++ b/tests/data/workflow-api-tests/tags/workflowapitestworkflow.py
@@ -1,0 +1,5 @@
+from leapp.tags import Tag
+
+
+class WorkflowApiTestWorkflowTag(Tag):
+    name = 'workflow_api_test_workflow'

--- a/tests/data/workflow-api-tests/topics/workflowapitopic.py
+++ b/tests/data/workflow-api-tests/topics/workflowapitopic.py
@@ -1,0 +1,5 @@
+from leapp.topics import Topic
+
+
+class WorkflowApiTopic(Topic):
+    name = 'workflow_api_topic'

--- a/tests/data/workflow-api-tests/workflows/workflow_api_test.py
+++ b/tests/data/workflow-api-tests/workflows/workflow_api_test.py
@@ -1,0 +1,27 @@
+from leapp.workflows import Workflow
+from leapp.workflows.phases import Phase
+from leapp.workflows.flags import Flags
+from leapp.workflows.tagfilters import TagFilter
+from leapp.workflows.policies import Policies
+from leapp.tags import FirstPhaseTag, SecondPhaseTag, WorkflowApiTestWorkflowTag
+
+
+class WorkflowApiTestWorkflow(Workflow):
+    name = 'WorkflowAPITest'
+    tag = WorkflowApiTestWorkflowTag
+    short_name = 'workflow_api_test'
+    description = '''No description has been provided for the WorkflowAPITest workflow.'''
+
+    class FirstPhase(Phase):
+        name = 'first_phase'
+        filter = TagFilter(FirstPhaseTag)
+        policies = Policies(Policies.Errors.FailPhase,
+                            Policies.Retry.Phase)
+        flags = Flags()
+
+    class SecondPhase(Phase):
+        name = 'second_phase'
+        filter = TagFilter(SecondPhaseTag)
+        policies = Policies(Policies.Errors.FailPhase,
+                            Policies.Retry.Phase)
+        flags = Flags()

--- a/tests/scripts/test_messaging.py
+++ b/tests/scripts/test_messaging.py
@@ -19,6 +19,7 @@ class FakeActor(object):
     produces = ()
     description = '''No description for a fake actor.'''
     tags = (TestTag.Common,)
+    apis = ()
 
     def process(self):
         pass

--- a/tests/scripts/test_repository_actor_definition.py
+++ b/tests/scripts/test_repository_actor_definition.py
@@ -16,6 +16,7 @@ _FAKE_META_DATA = {
     'consumes': (),
     'produces': (),
     'dialogs': (),
+    'apis': ()
 }
 
 
@@ -43,11 +44,13 @@ def test_actor_definition(repository_dir):
                     assert definition.dialogs == _FAKE_META_DATA['dialogs']
                     assert definition.name == _FAKE_META_DATA['name']
                     assert definition.description == _FAKE_META_DATA['description']
+                    assert definition.apis == _FAKE_META_DATA['apis']
                     dumped = definition.serialize()
                     assert dumped.pop('class_name') == definition.class_name
                     assert dumped.pop('description') == definition.description
                     assert dumped.pop('consumes') == definition.consumes
                     assert dumped.pop('produces') == definition.produces
+                    assert dumped.pop('apis') == definition.apis
                     assert dumped.pop('tags') == definition.tags
                     assert dumped.pop('dialogs') == [dialog.serialize() for dialog in definition.dialogs]
                     assert dumped.pop('path') == _FAKE_META_DATA['path']

--- a/tests/scripts/test_workflow_apis.py
+++ b/tests/scripts/test_workflow_apis.py
@@ -1,0 +1,11 @@
+import os.path
+import subprocess
+
+import py
+
+
+def test_workflow_api():
+    repository_path = py.path.local(
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'workflow-api-tests'))
+    with repository_path.as_cwd():
+        subprocess.check_call(['snactor', 'workflow', 'run', '--debug', 'WorkflowAPITest'])


### PR DESCRIPTION
This patch introduces initial necessary changes for the Workflow API
support. The Workflow API allows the actor to specify APIs to use and it
will not to have to specify anymore messages to consume or produce.

With this, it is possible to implement pure code API functions for actor
writers, where they do not have to work with messages but directly can
work with data.

This allows us to provide a stable API that is not changed, however we
can change the messages and system below.
Additionally we can use multiple versions of the API where we can allow
to change APIs in newer versions to make them more useful to consumers
of the API, however we could keep the old versions around to keep their
original code working.