### PR TITLE
Tupelize non tuples consumes, produces or apis

### DIFF
--- a/leapp/utils/__init__.py
+++ b/leapp/utils/__init__.py
@@ -15,9 +15,15 @@ def get_api_models(actor, what):
     :type actor: Actor or ActorDefinition
     :return: Tuple of all produced or consumed models as specified by actor and APIs used by the actor.
     """
+
+    def _enforce_tuple(x):
+        if not isinstance(x, tuple):
+            return (x,)
+        return x
+
     def _do_get(api):
-        result = getattr(api, what, ())
-        for a in api.apis or ():
+        result = _enforce_tuple(getattr(api, what, ()))
+        for a in _enforce_tuple(api.apis or ()):
             result = result + _do_get(a)
         return result
     return tuple(set(_do_get(actor)))

--- a/tests/data/workflow-api-tests/actors/secondphaseactor/actor.py
+++ b/tests/data/workflow-api-tests/actors/secondphaseactor/actor.py
@@ -1,17 +1,19 @@
 from leapp.actors import Actor
+from leapp.models import DepCheck1, DepCheck2
 from leapp.tags import SecondPhaseTag, WorkflowApiTestWorkflowTag
 from leapp.workflows.api.v3 import DepCheckAPI4
 
 
 class SecondPhaseActor(Actor):
     """
-    This is just an actor to ensure no inpact on actors in different phases. Nothing to do for it here.
+    This is just an actor to ensure no inpact on actors in different phases and that things like non tuple produces
+    or consumes are handled properly.
     """
 
     name = 'second_phase_actor'
-    consumes = ()
-    produces = ()
-    apis = (DepCheckAPI4,)
+    consumes = (DepCheck1)  # On purpose not a tuple
+    produces = (DepCheck2)  # On purpose not a tuple
+    apis = (DepCheckAPI4)  # On purpose not a tuple
     tags = (SecondPhaseTag, WorkflowApiTestWorkflowTag)
 
     def process(self):


### PR DESCRIPTION
Previously non tuples for consumes or produces fields did get
converted to a tuple. However with the introduction of the workflow apis
this behavior got reverted and caused some breakage. This patch adds
this behavior back and extends it even to apis fields.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>