### PR TITLE
Report inhibitors separately from errors

### DIFF
--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -2,17 +2,16 @@ import logging
 import os
 import sys
 
-
 from leapp.compat import string_types
 from leapp.dialogs import Dialog
-from leapp.exceptions import MissingActorAttributeError, WrongAttributeTypeError, StopActorExecutionError, \
-    StopActorExecution, WorkflowConfigNotAvailable
+from leapp.exceptions import (MissingActorAttributeError, RequestStopAfterPhase, StopActorExecution,
+                              StopActorExecutionError, WorkflowConfigNotAvailable, WrongAttributeTypeError)
 from leapp.models import DialogModel, Model
+from leapp.models.error_severity import ErrorSeverity
 from leapp.tags import Tag
 from leapp.utils import get_api_models
 from leapp.utils.i18n import install_translation_for_actor
 from leapp.utils.meta import get_flattened_subclasses
-from leapp.models.error_severity import ErrorSeverity
 from leapp.workflows.api import WorkflowAPI
 
 
@@ -338,6 +337,8 @@ class Actor(object):
             pass
         except StopActorExecutionError as err:
             self.report_error(err.message, err.severity, err.details)
+        except RequestStopAfterPhase:
+            self._messaging.request_stop_after_phase()
         finally:
             os.environ.pop('LEAPP_CURRENT_ACTOR', None)
 

--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -15,7 +15,8 @@ from leapp.messaging.answerstore import AnswerStore
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.utils.audit import Execution, get_connection, get_checkpoints
 from leapp.utils.clicmd import command, command_opt
-from leapp.utils.output import report_errors, report_info, beautify_actor_exception, report_unsupported
+from leapp.utils.output import (report_errors, report_info, beautify_actor_exception, report_unsupported,
+                                report_inhibitors)
 from leapp.utils.report import fetch_upgrade_report_messages, generate_report_file
 
 
@@ -230,6 +231,7 @@ def upgrade(args):
         workflow.run(context=context, skip_phases_until=skip_phases_until, skip_dialogs=True)
 
     report_errors(workflow.errors)
+    report_inhibitors(context)
     generate_report_files(context)
     report_files = get_cfg_files('report', cfg)
     log_files = get_cfg_files('logs', cfg)
@@ -276,6 +278,7 @@ def preupgrade(args):
     workflow.save_answers(answerfile_path, userchoices_path)
     generate_report_files(context)
     report_errors(workflow.errors)
+    report_inhibitors(context)
     report_files = get_cfg_files('report', cfg)
     log_files = get_cfg_files('logs', cfg)
     report_info(report_files, log_files, answerfile_path, fail=workflow.failure)

--- a/leapp/exceptions.py
+++ b/leapp/exceptions.py
@@ -130,3 +130,13 @@ class StopActorExecutionError(LeappError):
         super(StopActorExecutionError, self).__init__(message)
         self.severity = severity
         self.details = details
+
+
+class RequestStopAfterPhase(LeappError):
+    """
+    This exception is used to gracefully stop the current actor and request the stop of the workflow execution after
+    the current phase.
+    """
+
+    def __init__(self):
+        super(RequestStopAfterPhase, self).__init__('Stop after phase has been requested.')

--- a/leapp/messaging/__init__.py
+++ b/leapp/messaging/__init__.py
@@ -33,6 +33,7 @@ class BaseMessaging(object):
         self._stored = stored
         self._config_models = (config_model,) if config_model else ()
         self._dialogs = self._manager.list()
+        self._stop_after_phase = self._manager.Value(bool, False)
 
     def load_answers(self, answer_file, workflow):
         """
@@ -75,6 +76,15 @@ class BaseMessaging(object):
         :return: List of newly produced errors
         """
         return list(self._errors)
+
+    @property
+    def stop_after_phase(self):
+        """
+        Returns True if execution stop was requested after the current
+
+        :return: True if the executed was requested to be stopped.
+        """
+        return self._stop_after_phase.get()
 
     def messages(self):
         """
@@ -135,6 +145,12 @@ class BaseMessaging(object):
         model = ErrorModel(message=message, actor=actor.name, severity=severity, details=details,
                            time=datetime.datetime.now())
         self._do_produce(model, actor, self._errors)
+
+    def request_stop_after_phase(self):
+        """
+        If called, it will cause the workflow to stop the execution after the current phase ends.
+        """
+        self._stop_after_phase.set(True)
 
     def register_dialog(self, dialog, actor):
         self._dialogs.append(dialog)

--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -1,10 +1,13 @@
 from __future__ import print_function
+
 import json
 import sys
 from contextlib import contextmanager
 
-from leapp.models import ErrorModel
 from leapp.exceptions import LeappRuntimeError
+from leapp.models import ErrorModel
+from leapp.reporting import Flags
+from leapp.utils.report import fetch_upgrade_report_messages
 
 
 class Color(object):
@@ -15,12 +18,21 @@ class Color(object):
     yellow = "\033[1;33m" if sys.stdout.isatty() else ""
 
 
-def pretty_block(string, color=Color.bold, width=60):
+def pretty_block_text(string, color=Color.bold, width=60):
     return "\n{color}{separator}\n{text}\n{separator}{reset}\n".format(
         color=color,
         separator="=" * width,
         reset=Color.reset,
         text=string.center(width))
+
+
+@contextmanager
+def pretty_block(text, target, end_text=None, color=Color.bold, width=60):
+    target.write(pretty_block_text(text, color=color, width=width))
+    target.write('\n')
+    yield
+    target.write(pretty_block_text(end_text or 'END OF {}'.format(text), color=color, width=width))
+    target.write('\n')
 
 
 def print_error(error):
@@ -29,7 +41,7 @@ def print_error(error):
         red=Color.red, reset=Color.reset, severity=model.severity.upper(),
         message=model.message, time=model.time, actor=model.actor))
     if model.details:
-        print('Summary: ')
+        print('Summary:')
         details = json.loads(model.details)
         for detail in details:
             print('    {k}: {v}'.format(
@@ -37,13 +49,23 @@ def print_error(error):
                 v=details[detail].rstrip().replace('\n', '\n' + ' ' * (6 + len(detail)))))
 
 
+def report_inhibitors(context_id):
+    reports = fetch_upgrade_report_messages(context_id)
+    inhibitors = [report for report in reports if Flags.INHIBITOR in report.get('flags', [])]
+    if inhibitors:
+        text = 'UPGRADE INHIBITED'
+        with pretty_block(text=text, end_text=text, color=Color.red, target=sys.stdout):
+            print('Upgrade has been inhibited due to the following problems:')
+            for position, report in enumerate(inhibitors, start=1):
+                print('{idx:5}. Inhibitor: {title}'.format(idx=position, title=report['title']))
+            print('Consult the pre-upgrade report for details and possible remediation.')
+
+
 def report_errors(errors):
     if errors:
-        sys.stdout.write(pretty_block("ERRORS", color=Color.red))
-        sys.stdout.write("\n")
-        for error in errors:
-            print_error(error)
-        sys.stdout.write(pretty_block("END OF ERRORS", color=Color.red))
+        with pretty_block("ERRORS", target=sys.stderr, color=Color.red):
+            for error in errors:
+                print_error(error)
 
 
 def report_info(report_paths, log_paths, answerfile=None, fail=False):
@@ -56,33 +78,29 @@ def report_info(report_paths, log_paths, answerfile=None, fail=False):
             sys.stdout.write("Debug output written to {path}\n".format(path=log_path))
 
     if report_paths:
-        sys.stdout.write(pretty_block("REPORT", color=Color.bold if fail else Color.green))
-        sys.stdout.write("\n")
-        for report_path in report_paths:
-            sys.stdout.write("A report has been generated at {path}\n".format(path=report_path))
-        sys.stdout.write(pretty_block("END OF REPORT", color=Color.bold if fail else Color.green))
-        sys.stdout.write("\n")
+        with pretty_block("REPORT", target=sys.stdout, color=Color.bold if fail else Color.green):
+            for report_path in report_paths:
+                sys.stdout.write("A report has been generated at {path}\n".format(path=report_path))
 
     if answerfile:
         sys.stdout.write("Answerfile has been generated at {}\n".format(answerfile))
 
 
 def report_unsupported(devel_vars, experimental):
-    sys.stdout.write(pretty_block("UNSUPPORTED UPGRADE", color=Color.yellow))
-    sys.stdout.write("\nVariable LEAPP_UNSUPPORTED has been detected. Proceeding at your own risk.\n")
+    text = "UNSUPPORTED UPGRADE"
+    with pretty_block(text=text, end_text=text, target=sys.stdout, color=Color.yellow):
+        sys.stdout.write("Variable LEAPP_UNSUPPORTED has been detected. Proceeding at your own risk.\n")
 
-    if devel_vars:
-        sys.stdout.write("{yellow}Development variables{reset} have been detected:\n".format(
-            yellow=Color.yellow, reset=Color.reset))
-        for key in devel_vars:
-            sys.stdout.write("- {key}={value}\n".format(key=key, value=devel_vars[key]))
-    if experimental:
-        sys.stdout.write("{yellow}Experimental actors{reset} have been detected:\n".format(
-            yellow=Color.yellow, reset=Color.reset))
-        for actor in experimental:
-            sys.stdout.write("- {actor}\n".format(actor=actor))
-    sys.stdout.write(pretty_block("UNSUPPORTED UPGRADE", color=Color.yellow))
-    sys.stdout.write("\n")
+        if devel_vars:
+            sys.stdout.write("{yellow}Development variables{reset} have been detected:\n".format(
+                yellow=Color.yellow, reset=Color.reset))
+            for key in devel_vars:
+                sys.stdout.write("- {key}={value}\n".format(key=key, value=devel_vars[key]))
+        if experimental:
+            sys.stdout.write("{yellow}Experimental actors{reset} have been detected:\n".format(
+                yellow=Color.yellow, reset=Color.reset))
+            for actor in experimental:
+                sys.stdout.write("- {actor}\n".format(actor=actor))
 
 
 @contextmanager
@@ -93,6 +111,6 @@ def beautify_actor_exception():
         except LeappRuntimeError as e:
             msg = '{} - Please check the above details'.format(e.message)
             sys.stderr.write("\n")
-            sys.stderr.write(pretty_block(msg, color="", width=len(msg)))
+            sys.stderr.write(pretty_block_text(msg, color="", width=len(msg)))
     finally:
         pass

--- a/leapp/workflows/__init__.py
+++ b/leapp/workflows/__init__.py
@@ -83,7 +83,7 @@ class Workflow(with_metaclass(WorkflowMeta)):
 
     @property
     def failure(self):
-        return self._errors or self._unhandled_exception
+        return self._errors or self._unhandled_exception or self._stop_after_phase_requested
 
     @property
     def answer_store(self):
@@ -136,6 +136,7 @@ class Workflow(with_metaclass(WorkflowMeta)):
         self._unhandled_exception = False
         self._answer_store = AnswerStore()
         self._dialogs = []
+        self._stop_after_phase_requested = False
 
         if self.configuration:
             config_actors = [actor for actor in self.tag.actors if self.configuration in actor.produces]
@@ -279,6 +280,7 @@ class Workflow(with_metaclass(WorkflowMeta)):
             if phase and not self.is_valid_phase(phase):
                 raise CommandError('Phase {phase} does not exist in the workflow'.format(phase=phase))
 
+        self._stop_after_phase_requested = False
         for phase in self._phase_actors:
             os.environ['LEAPP_CURRENT_PHASE'] = phase[0].name
             if skip_phases_until:
@@ -316,6 +318,8 @@ class Workflow(with_metaclass(WorkflowMeta)):
                     except BaseException:
                         self._unhandled_exception = True
                         raise
+
+                    self._stop_after_phase_requested = messaging.stop_after_phase or self._stop_after_phase_requested
 
                     # Collect dialogs
                     self._dialogs.extend(messaging.dialogs())
@@ -359,6 +363,10 @@ class Workflow(with_metaclass(WorkflowMeta)):
                 self.log.info('Workflow finished due to the until-phase flag')
                 early_finish = True
 
+            elif self._stop_after_phase_requested:
+                self.log.info('Workflow received request to stop after phase.')
+                early_finish = True
+
             elif phase[0].flags.request_restart_after_phase or phase[0].flags.restart_after_phase:
                 reboot = True
                 if phase[0].flags.request_restart_after_phase and not self._auto_reboot:
@@ -370,6 +378,7 @@ class Workflow(with_metaclass(WorkflowMeta)):
                     self.log.info('Initiating system reboot due to the restart_after_reboot flag')
                     reboot_system()
                 early_finish = True
+
             elif phase[0].flags.is_checkpoint:
                 self.log.info('Stopping the workflow execution due to the is_checkpoint flag')
                 early_finish = True

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 1.0
+%global framework_version 1.1
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage


### PR DESCRIPTION
Previously there was no separation of errors and inhibitors in the
reports and the output of the leapp tool.
This patch separates the output on the commandline and filters out the
inhibitor messages from the report to avoid duplication of the
information in the report.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>