### PR TITLE
Show progress in non verbose executions

### DIFF
--- a/leapp/workflows/__init__.py
+++ b/leapp/workflows/__init__.py
@@ -13,6 +13,7 @@ from leapp.tags import ExperimentalTag
 from leapp.utils import reboot_system
 from leapp.utils.audit import checkpoint, get_errors
 from leapp.utils.meta import with_metaclass, get_flattened_subclasses
+from leapp.utils.output import display_status_current_phase, display_status_current_actor
 from leapp.workflows.phases import Phase
 from leapp.workflows.policies import Policies
 from leapp.workflows.phaseactors import PhaseActors
@@ -289,6 +290,7 @@ class Workflow(with_metaclass(WorkflowMeta)):
                 self.log.info('Skipping phase {name}'.format(name=phase[0].name))
                 continue
 
+            display_status_current_phase(phase)
             self.log.info('Starting phase {name}'.format(name=phase[0].name))
             current_logger = self.log.getChild(phase[0].name)
 
@@ -307,6 +309,8 @@ class Workflow(with_metaclass(WorkflowMeta)):
                         if actor not in self.experimental_whitelist:
                             current_logger.info("Skipping experimental actor {actor}".format(actor=actor.name))
                             continue
+
+                    display_status_current_actor(actor, designation=designation)
                     current_logger.info("Executing actor {actor} {designation}".format(designation=designation,
                                                                                        actor=actor.name))
                     messaging = InProcessMessaging(config_model=config_model, answer_store=self._answer_store)


### PR DESCRIPTION
Previously when leapp was executed not much was visible during the
upgrade except for the DNF output. This patch now introduces some
changes to the execution that shows what phase starts and which
actor gets executed.

Example output:
```
[root@localhost leapp]# leapp preupgrade
==> Processing phase `configuration_phase`
====> * ipu_workflow_config
        IPU workflow config actor
==> Processing phase `FactsCollection`
====> * scanmemory
        Scan Memory of the machine.
====> * tcp_wrappers_config_read
        Parse tcp_wrappers configuration files /etc/hosts.{allow,deny}.
====> * scan_kernel_cmdline
        No documentation has been provided for the scan_kernel_cmdline actor.
====> * storage_scanner
        Provides data about storage settings.
====> * system_facts
        Provides data about many facts from system.
====> * udevadm_info
        Produces data exported by the "udevadm info" command.
====> * scan_subscription_manager_info
        Scans the current system for subscription manager information
====> * transaction_workarounds
        Provides additional RPM transaction tasks based on bundled RPM packages.
====> * rpm_scanner
        Provides data about installed RPM Packages.
Loaded plugins: product-id, subscription-manager
====> * network_manager_read_config
        Provides data about NetworkManager configuration.
====> * repository_mapping
        Produces message containing repository mapping based on provided file.
====> * sssd_facts
        Check SSSD configuration for changes in RHEL8 and report them in model.
====> * root_scanner
        Scan the system root directory and produce a message containing
====> * pam_modules_scanner
        Scan the pam directory for services and modules used in them
====> * pci_devices_scanner
        Provides data about existing PCI Devices.
```

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>