### PR TITLE
Add --no-rhsm and LEAPP_NO_RHSM for skipping RHSM

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -161,6 +161,8 @@ def prepare_configuration(args):
         os.environ['LEAPP_NO_RHSM'] = '1'
     elif os.getenv('LEAPP_NO_RHSM') != '1':
         os.environ['LEAPP_NO_RHSM'] = os.getenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+    if args.enablerepo:
+        os.environ['LEAPP_ENABLE_REPOS'] = ','.join(args.enablerepo)
     configuration = {
         'debug': os.getenv('LEAPP_DEBUG', '0'),
         'verbose': os.getenv('LEAPP_VERBOSE', '0'),
@@ -181,14 +183,16 @@ def process_whitelist_experimental(repositories, workflow, configuration, logger
             raise CommandError(msg)
 
 
-@command('upgrade', help='Upgrades the current system to the next available major version.')
+@command('upgrade', help='Upgrade the current system to the next available major version.')
 @command_opt('resume', is_flag=True, help='Continue the last execution after it was stopped (e.g. after reboot)')
 @command_opt('reboot', is_flag=True, help='Automatically performs reboot when requested.')
-@command_opt('whitelist-experimental', action='append', metavar='ActorName', help='Enables experimental actors')
+@command_opt('whitelist-experimental', action='append', metavar='ActorName', help='Enable experimental actors')
 @command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
 @command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'
                                            ' with Red Hat Subscription Manager')
+@command_opt('enablerepo', action='append', metavar='<repoid>',
+             help='Enable specified repository. Can be used multiple times.')
 def upgrade(args):
     skip_phases_until = None
     context = str(uuid.uuid4())
@@ -253,6 +257,8 @@ def upgrade(args):
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
 @command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'
                                            ' with Red Hat Subscription Manager')
+@command_opt('enablerepo', action='append', metavar='<repoid>',
+             help='Enable specified repository. Can be used multiple times.')
 def preupgrade(args):
     context = str(uuid.uuid4())
     cfg = get_config()

--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -142,11 +142,11 @@ def handle_output_level(args):
     """
     Set environment variables following command line arguments.
     """
-    os.environ['LEAPP_DEBUG'] = '1' if args.debug else os.environ.get('LEAPP_DEBUG', '0')
+    os.environ['LEAPP_DEBUG'] = '1' if args.debug else os.getenv('LEAPP_DEBUG', '0')
     if os.environ['LEAPP_DEBUG'] == '1' or args.verbose:
         os.environ['LEAPP_VERBOSE'] = '1'
     else:
-        os.environ['LEAPP_VERBOSE'] = os.environ.get('LEAPP_VERBOSE', '0')
+        os.environ['LEAPP_VERBOSE'] = os.getenv('LEAPP_VERBOSE', '0')
 
 
 def prepare_configuration(args):
@@ -157,10 +157,14 @@ def prepare_configuration(args):
     else:
         os.environ['LEAPP_EXPERIMENTAL'] = '0'
     os.environ['LEAPP_UNSUPPORTED'] = '0' if os.getenv('LEAPP_UNSUPPORTED', '0') == '0' else '1'
+    if args.no_rhsm:
+        os.environ['LEAPP_NO_RHSM'] = '1'
+    elif os.getenv('LEAPP_NO_RHSM') != '1':
+        os.environ['LEAPP_NO_RHSM'] = os.getenv('LEAPP_DEVEL_SKIP_RHSM', '0')
     configuration = {
         'debug': os.getenv('LEAPP_DEBUG', '0'),
         'verbose': os.getenv('LEAPP_VERBOSE', '0'),
-        'whitelist_experimental': args.whitelist_experimental or ()
+        'whitelist_experimental': args.whitelist_experimental or (),
     }
     return configuration
 
@@ -183,6 +187,8 @@ def process_whitelist_experimental(repositories, workflow, configuration, logger
 @command_opt('whitelist-experimental', action='append', metavar='ActorName', help='Enables experimental actors')
 @command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
+@command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'
+                                           ' with Red Hat Subscription Manager')
 def upgrade(args):
     skip_phases_until = None
     context = str(uuid.uuid4())
@@ -245,6 +251,8 @@ def upgrade(args):
 @command_opt('whitelist-experimental', action='append', metavar='ActorName', help='Enables experimental actors')
 @command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
+@command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'
+                                           ' with Red Hat Subscription Manager')
 def preupgrade(args):
     context = str(uuid.uuid4())
     cfg = get_config()

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 1.1
+%global framework_version 1.2
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage


### PR DESCRIPTION
The behavior is the same as the legacy `LEAPP_DEVEL_SKIP_RHSM`, except supported.

Requries Repo PR: oamg/leapp-repository/pull/482