### PR TITLE
Fix output location for errors block

### DIFF
--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -70,7 +70,7 @@ def report_inhibitors(context_id):
 
 def report_errors(errors):
     if errors:
-        with pretty_block("ERRORS", target=sys.stderr, color=Color.red):
+        with pretty_block("ERRORS", target=sys.stdout, color=Color.red):
             for error in errors:
                 print_error(error)
 


### PR DESCRIPTION
Previously the location of the pretty block for ERRORS has been
accidentally changed from stdout to stderr. This patch reverts this
mistake.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>