### PR TITLE
Release 0.10.0

### DIFF
--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,6 +1,6 @@
 from leapp.utils.workarounds import apply_workarounds
 
-VERSION = "0.9.0"
+VERSION = "0.10.0"
 FULL_VERSION = VERSION
 
 apply_workarounds()

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,4 +1,4 @@
-.TH LEAPP "1" "17/04/2019" "leapp 0.9.0" "User Commands"
+.TH LEAPP "1" "2020-04-16" "leapp 0.10.0" "User Commands"
 .SH NAME
 leapp - command-line interface to for App & OS Modernization Framework Leapp
 .SH SYNOPSIS

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,4 +1,4 @@
-.TH SNACTOR "1" "17/04/2019" "snactor 0.9.0" "User Commands"
+.TH SNACTOR "1" "2020-04-16" "snactor 0.10.0" "User Commands"
 .SH NAME
 snactor - development and repository management tool for App & OS Modernization Framework Leapp
 .SH SYNOPSIS

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -32,7 +32,7 @@
 %endif
 
 Name:       leapp
-Version:    0.9.0
+Version:    0.10.0
 Release:    1%{?dist}
 Summary:    OS & Application modernization framework
 


### PR DESCRIPTION
## Packaging
- Add BuildRequires on python2-setuptools
- Add new dependency on python2-requests
- Add unversioned dependency on leapp-repository and provide
  the leapp-framework capability in python2-leapp (see docs about
  "new dependency mechanism") (#591)
- Move all leapp and snactor files into related rpms instead of python?-leapp (#591)
- Remove dependency on Jinja2

## Framework
### Fixes
- Fix json export capabilities using serialization (#598)

### Enhancements
- Add the DESKTOP tag for the leapp report (#612)
- Dialogs are non-interactive and redesigned significantly; but in beta support
  (see the known issue)
- Introduce DialogModel that could be processed by actors to add related
  information into the report (#589)
- Introduce Workflow API (see the Workflow APIs tutorial) (#618)
- Report inhibitors separately from errors on stdout (#620)
- Show progress in non-verbose executions (#621)

### Known issue
- The answerfile is not generated on some machines after the run of leapp.
  Currently it's under investigation.

## Leapp
### Fixes
- Print message about generated report when `leapp upgrade` ends, as we do for
  `leapp preupgrade` (#573)

### Enhancements
- Add `leapp answer` to answer Dialog questions in CLI (#592)
- Add the --no-rhsm option for (pre)upgrade commands (#622)
- Add the --enablerepo option for Leapp to use an existing custom yum/dnf
repository during the upgrade
- Display a warning when leapp is used in an unsupported (devel/testing) mode (#577)
- Print errors on stdout in pretty format (#593)
- Error messages are now part of the preupgrade report
- The verbosity options (--verbose | --debug) are available for leapp commands as well

## stdlib
### Enhancements
- Add `stdin` and `encoding` parameters in the run function (#583, #595)

## Modifications
- Code is compatible with Python3 pylint