### PR TITLE
Fix handling of debug/verbose in {pre,}upgrade

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -197,13 +197,13 @@ def upgrade(args):
     skip_phases_until = None
     context = str(uuid.uuid4())
     cfg = get_config()
+    handle_output_level(args)
     configuration = prepare_configuration(args)
     answerfile_path = cfg.get('report', 'answerfile')
     userchoices_path = cfg.get('report', 'userchoices')
 
     if os.getuid():
         raise CommandError('This command has to be run under the root user.')
-    handle_output_level(args)
 
     if args.resume:
         context, configuration = fetch_last_upgrade_context()
@@ -262,13 +262,13 @@ def upgrade(args):
 def preupgrade(args):
     context = str(uuid.uuid4())
     cfg = get_config()
+    handle_output_level(args)
     configuration = prepare_configuration(args)
     answerfile_path = cfg.get('report', 'answerfile')
     userchoices_path = cfg.get('report', 'userchoices')
 
     if os.getuid():
         raise CommandError('This command has to be run under the root user.')
-    handle_output_level(args)
     e = Execution(context=context, kind='preupgrade', configuration=configuration)
     e.store()
     archive_logfiles()


### PR DESCRIPTION
Previously changes have been introduced that caused the debug/verbose
information not to be stored correctly to the database, which led to
different output behavior after reboot. (No debug/verbose output after
resuming the execution)

This patch changes the order when this data is processed so the
configuration is updated correctly.

JIRA-Taks: OAMG-3087
Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>