### PR TITLE
[WIP] Remove actor libs from meta_path when exiting context

### DIFF
--- a/leapp/repository/actor_definition.py
+++ b/leapp/repository/actor_definition.py
@@ -270,6 +270,8 @@ class ActorDefinition(object):
             yield
         finally:
             os.chdir(previous_path)
+            sys.meta_path.pop()
+            # TODO also clean sys.modules. Since they are accumulated as well
 
             # Restoration of the PATH environment variable
             os.environ['PATH'] = path_backup


### PR DESCRIPTION
This allows running actors tests safely within one pytest
session.

# TODO:
- [ ] investigate and fix pipelines

Might be merged only after:
- [ ] https://github.com/oamg/leapp-repository/pull/500