### PR TITLE
Add --actor-config to snactor run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ container-test:
 	docker run --rm -ti -v ${PWD}:/payload leapp-tests
 
 test:   lint
-	pytest --cov-report term-missing --cov=leapp tests/scripts
+	pytest -vv --cov-report term-missing --cov=leapp tests/scripts
 
 lint:
 	pytest --cache-clear --pylint -m pylint leapp tests/scripts/*.py

--- a/docs/source/el7toel8/actor-rhel7-to-rhel8.md
+++ b/docs/source/el7toel8/actor-rhel7-to-rhel8.md
@@ -269,7 +269,6 @@ reporting.RelatedResource('pam', 'pam_securetty')
 
 The related resources are especially useful when you have a lot of accompanied objects like files or directories by your report and you would like to present it to the user in a specific way.
 
-
 ## Testing your new actor
 
 During development of your new actor, it is expected that you will test your work to verify that results match your expectations. You can do that by manually executing your actor, or writing tests on various levels (i.e unit tests, component tests, E2E tests).
@@ -312,6 +311,22 @@ As you can see the actor is executed without errors. But, by default, snactor do
 ```
 
 Now we can see that the _OSReleaseCollector_ actor produced a message of the _OSReleaseFacts_ model, containing data like OS Release name and version.
+
+### Executing a single actor that uses the workflow config
+
+If you need to execute an actor on its own that requires the `IPUConfig` model you can execute the actor with the
+following command:
+
+```shell
+snactor run --actor-config IPUConfig ActorName
+```
+
+In order for this to work you have to run the `IPUWorkflowConfig` actor before and save its output, so that the config
+data is stored in the database for the current session:
+
+```shell
+snactor run --save-output IPUWorkflowConfig
+```
 
 ### Executing the whole upgrade workflow with the new actor
 
@@ -435,4 +450,4 @@ When filing an issue, include:
 
 ## Where can I seek help?
 
-We’ll gladly answer your questions and lead you to through any troubles with the actor development. You can reach us, the OS and Application Modernization Group, at freenode IRC server in channel __#leapp__.
+We’ll gladly answer your questions and lead you to through any troubles with the actor development. You can reach us, the OS and Application Modernization Group, at freenode IRC server in channel **#leapp**.

--- a/leapp/messaging/__init__.py
+++ b/leapp/messaging/__init__.py
@@ -9,10 +9,10 @@ from six.moves import configparser
 
 from leapp.dialogs import RawMessageDialog
 from leapp.dialogs.renderer import CommandlineRenderer
-from leapp.messaging.answerstore import AnswerStore
 from leapp.exceptions import CannotConsumeErrorMessages
-from leapp.models import DialogModel, ErrorModel
+from leapp.messaging.answerstore import AnswerStore
 from leapp.messaging.commands import WorkflowCommand
+from leapp.models import DialogModel, ErrorModel
 from leapp.utils import get_api_models
 
 

--- a/leapp/snactor/commands/messages/__init__.py
+++ b/leapp/snactor/commands/messages/__init__.py
@@ -1,9 +1,17 @@
+import json
 import os
+import sys
+from importlib import import_module
 
-from leapp.utils.clicmd import command
-from leapp.utils.repository import requires_repository
+from leapp.exceptions import CommandError, LeappError, ModelDefinitionError
+from leapp.logger import configure_logger
+from leapp.messaging.inprocess import InProcessMessaging
+from leapp.models.fields import ModelViolationError
+from leapp.repository.scan import find_and_scan_repositories
 from leapp.snactor.context import with_snactor_context
-from leapp.utils.audit import get_connection, get_config
+from leapp.utils.audit import get_config, get_connection
+from leapp.utils.clicmd import command, command_arg, command_opt
+from leapp.utils.repository import find_repository_basedir, requires_repository
 
 _MAIN_LONG_DESCRIPTION = '''
 This group of commands are around managing messages stored in the
@@ -29,8 +37,18 @@ https://red.ht/leapp-docs
 '''
 
 
+_ADD_LONG_DESCRIPTION = '''
+With this command messages in the current repository scope can be added.
+This gives the developer control over the input data available to actors
+run and developed in this repository.
+
+For more information please consider reading the documentation at:
+https://red.ht/leapp-docs
+'''
+
+
 @messages.command('clear', help='Deletes all messages from the current repository scope',
-                  description=_CLEAR_LONG_DESCRIPTION)
+                  description=_ADD_LONG_DESCRIPTION)
 @requires_repository
 @with_snactor_context
 def clear(args):  # noqa; pylint: disable=unused-argument
@@ -40,3 +58,31 @@ def clear(args):  # noqa; pylint: disable=unused-argument
     ))
     with get_connection(None) as con:
         con.execute("DELETE FROM message WHERE context = ?", (os.environ["LEAPP_EXECUTION_ID"],))
+
+
+class Injector(object):
+    name = 'injector'
+
+
+@messages.command('add', help='Adds a message to the current repository scope',
+                  description=_CLEAR_LONG_DESCRIPTION)
+@command_opt('model', short_name='m', help='Model to add')
+@command_arg('data', help='Data to add in JSON format')
+@requires_repository
+@with_snactor_context
+def add(args):  # noqa; pylint: disable=unused-argument
+    basedir = find_repository_basedir('.')
+    repository = find_and_scan_repositories(basedir, include_locals=True)
+    try:
+        repository.load()
+    except LeappError as exc:
+        sys.stderr.write(exc.message)
+        sys.stderr.write('\n')
+        sys.exit(1)
+    try:
+        model = getattr(import_module('leapp.models'), args.model, None)
+        InProcessMessaging().produce(model.create(json.loads(args.data)), Injector())
+    except ModelDefinitionError:
+        raise CommandError('No such model: {}'.format(args.model))
+    except ModelViolationError as e:
+        raise CommandError('Invalid data format for model: {}\n    => {}'.format(args.model, e.message))

--- a/leapp/snactor/commands/run.py
+++ b/leapp/snactor/commands/run.py
@@ -1,15 +1,15 @@
+from importlib import import_module
 import json
 import sys
 
-from leapp.exceptions import LeappError, CommandError
-from leapp.utils.clicmd import command, command_opt, command_arg
-from leapp.utils.repository import requires_repository, find_repository_basedir
+from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.messaging.inprocess import InProcessMessaging
-from leapp.utils.output import report_errors, beautify_actor_exception
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.snactor.context import with_snactor_context
-
+from leapp.utils.clicmd import command, command_arg, command_opt
+from leapp.utils.output import beautify_actor_exception, report_errors
+from leapp.utils.repository import find_repository_basedir, requires_repository
 
 _LONG_DESCRIPTION = '''
 Runs the given actor as specified as `actor_name` in a testing environment.
@@ -21,8 +21,9 @@ https://red.ht/leapp-docs
 
 @command('run', help='Execute the given actor', description=_LONG_DESCRIPTION)
 @command_arg('actor-name')
-@command_opt('--save-output', is_flag=True)
-@command_opt('--print-output', is_flag=True)
+@command_opt('--actor-config', help='Name of the workflow config model to use')
+@command_opt('--save-output', is_flag=True, help='Save the produced messages by this actor.')
+@command_opt('--print-output', is_flag=True, help='Print the produced messages by this actor.')
 @requires_repository
 @with_snactor_context
 def cli(args):
@@ -39,13 +40,14 @@ def cli(args):
     actor = repository.lookup_actor(args.actor_name)
     if not actor:
         raise CommandError('Actor "{}" not found!'.format(args.actor_name))
-    messaging = InProcessMessaging(stored=args.save_output)
+    config_model = getattr(import_module('leapp.models'), args.actor_config) if args.actor_config else None
+    messaging = InProcessMessaging(stored=args.save_output, config_model=config_model)
     messaging.load(actor.consumes)
 
     failure = False
     with beautify_actor_exception():
         try:
-            actor(messaging=messaging, logger=actor_logger).run()
+            actor(messaging=messaging, logger=actor_logger, config_model=config_model).run()
         except BaseException:
             failure = True
             raise

--- a/leapp/utils/workarounds/mp.py
+++ b/leapp/utils/workarounds/mp.py
@@ -16,7 +16,7 @@ def apply_workaround():
             super(FixedFinalize, self).__init__(*args, **kwargs)
             self._pid = os.getpid()
 
-        def __call__(self, *args, **kwargs):    # pylint: disable=signature-differs
+        def __call__(self, *args, **kwargs):  # pylint: disable=signature-differs
             if self._pid != os.getpid():
                 return None
             return super(FixedFinalize, self).__call__(*args, **kwargs)


### PR DESCRIPTION
This patch introduces support for specifying a model which the actor
should consume for configuration data.
Using this feature requires to run an actor before which produces this
model and saves the output.

Jira-Task: OAMG-1092

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>
Fixes #530