### PR TITLE
Chore/docs/update docs with using pytest and name conventions

### DIFF
--- a/docs/source/best-practices.md
+++ b/docs/source/best-practices.md
@@ -43,6 +43,11 @@ to a shared library function. You can introduce it in one of these two places:
   writing your actor for, e.g. for an OS in-place upgrade workflow, should go to the `<Leapp repository>/libraries`
   folder. In this case, we welcome your proposals under the
   [leapp-repository on GitHub](https://github.com/oamg/leapp-repository).
+  
+  Please note that the name of the library module in this case should be unique and contain
+  the actor name. For example:
+  `repos/system_upgrade/el7toel8/actors/vimmigrate/libraries/vimmigrate.py`
+ 
 
 ## Discover standard library functions
 
@@ -93,7 +98,7 @@ improve the respective actors.
 Write all the actor’s logic in the actor’s private library in order to be able to write unit tests for each of the
 function. It is not currently possible to unit test any method or function in the _actor.py_. Then, ideally, the
 `actor.process()` should contain only calling an entry point to the actor's library. To create an actor’s library,
-create _libraries_ folder in the actor’s folder and in there create an arbitrarily named python file, e.g. _library.py_.
+create _libraries_ folder in the actor’s folder and in there create an arbitrarily named python file, e.g. _{actor_name}.py_.
 
 _myactor/actor.py_:
 
@@ -106,7 +111,7 @@ class MyActor(Actor):
         do_the_actor_thingy(self)
 ```
 
-_myactor/libraries/library.py_:
+_myactor/libraries/myactor.py_:
 
 ```python
 def do_the_actor_thingy(actor):

--- a/docs/source/repository-dir-layout.md
+++ b/docs/source/repository-dir-layout.md
@@ -1,53 +1,54 @@
 # Repository Directory Layout
 
 ```
- .leapp/                            # Repository information. Do not edit it manually.
- actors/                            # All actors are stored here in subdirectories.
-    actorname/                      # An actor directory.
-        actor.py                    # The actual actor code. The file name actor.py is required.
-        Makefile                    # Optional makefile with target install-deps to install
-                                    # actor's dependencies for tests execution.
-        tests/                      # Unit and component tests for the actors are to be stored here.
-            test_actor.py
-            files/                  # If tests need to use some mocked files, they should be placed here
-                                    # and referenced from the tests using path 'tests/files'.
-        libraries/                  # Private libraries for the actors only.
-            private.py              # These can be modules
-            actorpkg/               # or packages.
+ .leapp/                                        # Repository information. Do not edit it manually.
+ actors/                                        # All actors are stored here in subdirectories.
+    actorname/                                  # An actor directory.
+        actor.py                                # The actual actor code. The file name actor.py is required.
+        Makefile                                # Optional makefile with target install-deps to install
+                                                # actor's dependencies for tests execution.
+        tests/                                  # Unit and component tests for the actors are to be stored here.
+            unit_test_actorname.py              # should contain the actor name
+            component_test_actorname.py         # should contain the actor name
+            files/                              # If tests need to use some mocked files, they should be placed here
+                                                # and referenced from the tests using path 'tests/files'.
+        libraries/                              # Private libraries for the actors only.
+            private_actorname.py                # These can be modules. Name should contain actor name
+            actorpkg/                           # or packages.
                 __init__.py
-        tools/                      # The path of this directory gets injected in the actors PATH
-                                    # environment variable before their execution. These tools are private to
-                                    # the actor.
+        tools/                                  # The path of this directory gets injected in the actors PATH
+                                                # environment variable before their execution. These tools are private to
+                                                # the actor.
 
-        files/                      # Files that are private to the actor only.
+        files/                                  # Files that are private to the actor only.
 
- files/                             # Files that are shared with all actors (common files).
+ files/                                         # Files that are shared with all actors (common files).
 
- libraries/                         # Libraries that are shared with all actors.
-    common.py                       # These can be modules
-    tests/                          # with tests stored here.
-        files/                      # If tests need to use some mocked files, they should be placed here
-                                    # and refenreced from the tests using path 'tests/files'.
+ libraries/                                     # Libraries that are shared with all actors.
+    common.py                                   # These can be modules
+    tests/                                      # with tests stored here.
+        files/                                  # If tests need to use some mocked files, they should be placed here
+                                                # and refenreced from the tests using path 'tests/files'.
         test_common.py
-    sharedpkg/                      # Or they can be packages
+    sharedpkg/                                  # Or they can be packages
         __init__.py
-        tests/                      # with tests stored here.
+        tests/                                  # with tests stored here.
             test_sharedpkg.py
-            files/                  # If tests need to use some mocked files, they should be placed here
-                                    # and refenreced from the tests using path 'sharedpkg/tests/files'.
+            files/                              # If tests need to use some mocked files, they should be placed here
+                                                # and refenreced from the tests using path 'sharedpkg/tests/files'.
 
- models/                            # All models describing the message payload format are stored here.
+ models/                                        # All models describing the message payload format are stored here.
     model.py
 
- tags/                              # All tags for this repository are stored here.
+ tags/                                          # All tags for this repository are stored here.
     tag.py
 
- tools/                             # The path of this directory gets injected in the PATH environment
-                                    # variable before actors execution. These tools are shared with all actors.
+ tools/                                         # The path of this directory gets injected in the PATH environment
+                                                # variable before actors execution. These tools are shared with all actors.
 
- topics/                            # All topics for this repository are stored here.
+ topics/                                        # All topics for this repository are stored here.
     topic.py
 
- workflows/                         # Workflows are stored here.
+ workflows/                                     # Workflows are stored here.
     workflow.py
 ```

--- a/docs/source/test-actors.md
+++ b/docs/source/test-actors.md
@@ -5,6 +5,7 @@ The Leapp actors are covered by three types of tests - unit, component and e2e.
 ## Unit and component tests
 
 - Both unit and component tests are to be placed in the actor's _tests_ folder.
+- Unit and component tests modules should have unique names
 - Tutorial on [How to write unit and component tests](unit-testing)
 
 ### Unit tests
@@ -12,7 +13,7 @@ The Leapp actors are covered by three types of tests - unit, component and e2e.
 - These tests deal with individual actor's functions/methods.
 - It's not possible to unit test any method/function within the *actor.py*. You can write unit tests only for functions/methods within the actor's libraries.
 - Thus, to be able to write unit tests for an actor, ideally the only thing in the _actor.py_'s _process()_ method is calling the entry-point function of the actor's library python module.
-- [Example of unit tests](https://github.com/oamg/leapp-repository/blob/master/repos/system_upgrade/el7toel8/actors/checkbootavailspace/tests/unit_test.py)
+- [Example of unit tests](https://github.com/oamg/leapp-repository/blob/master/repos/system_upgrade/el7toel8/actors/checkbootavailspace/tests/unit_test_checkbootavailspace.py)
 
 ### Component tests
 

--- a/docs/source/unit-testing.md
+++ b/docs/source/unit-testing.md
@@ -215,7 +215,7 @@ More examples could be found in the
 ### Shared libraries' tests
 
 To run tests of all shared libraries (i.e. libraries stored in
-`repositories/system_upgrade/el7toel8/libraries`) environment variable
+`repo/system_upgrade/el7toel8/libraries`) environment variable
 `TEST_LIBS` need to be set (only in case you use make command):
 
 ```sh

--- a/docs/source/unit-testing.md
+++ b/docs/source/unit-testing.md
@@ -22,8 +22,8 @@ actors\
     myactor\
         actor.py
         tests\
-            component_test.py
-            unit_test.py
+            component_test_my_actor.py
+            unit_test_my_actor.py
 ```
 
 ### Naming conventions
@@ -33,13 +33,16 @@ all test functions have to:
 
 - reside in `test_*.py` or `*_test.py` files,
 - be prefixed by `test_`.
+- test modules should have unique names, and we use the following convention
+`test_*_{actor_name}.py`. For example: `test_unit_sctpconfigread.py` or
+`component_test_sctpconfigread.py`
 
 See the [pytest documentation](https://docs.pytest.org/en/latest/goodpractices.html#tests-outside-application-code).
 
 ### Writing tests that execute the whole actor - component tests
 
 Now let's assume you want to write a test that executes the actor. This is how
-your `component_test.py` from above could look like:
+your `component_test_{actor_name}.py` from above could look like:
 
 ```python
 def test_actor_execution(current_actor_context):
@@ -108,19 +111,20 @@ supposed to be unit tested is necessary to move into the actor's private
 library. Modules from the private library can then be imported not only from
 the `actor.py` but also from the test modules.
 
-Let's assume your actor has a private library module called `private.py`.
+Let's assume your actor has a private library module called 
+`private_{actor_name}.py`.
 
 ```
 actors\
     myactor\
         actor.py
         libraries\
-            private.py
+            private_myactor.py
         tests\
-            unit_test.py
+            unit_test_my_actor.py
 ```
 
-And the `private.py` looks like this:
+And the `private_my_actor.py` looks like this:
 
 ```python
 def my_function(value):
@@ -130,7 +134,7 @@ def my_function(value):
 You can easily write a test for this library like this:
 
 ```python
-    from leapp.libraries.actor import private
+    from leapp.libraries.actor import private_my_actor
 
     def test_my_actor_library():
         assert private.my_function(0) == 42
@@ -185,40 +189,55 @@ Makefile of `leapp-repository` provides target for testing your actors.
 Issue `make test` in the root directory of the `leapp-repository` GitHub repository
 to test all actors.
 
+You can also run tests by simply running `pytest`
+
 To test specific actor using makefile, set `ACTOR` environment variable:
 
 ```sh
 ACTOR=myactor make test
 ```
 
+or
+
+```sh
+pytest {PATH_TO_ACTOR}
+```
+
+It is also possible to run only slected tests based on their name:
+
+```sh
+pytest -k "vim"    # to run all tests contains vim in name
+pytest -k "not vim"    # to run all tests, which not contains vim in name
+```
+More examples could be found in the 
+[pytest documentation](https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name)
+
 ### Shared libraries' tests
 
 To run tests of all shared libraries (i.e. libraries stored in
 `repositories/system_upgrade/el7toel8/libraries`) environment variable
-`TEST_LIBS` need to be set:
+`TEST_LIBS` need to be set (only in case you use make command):
 
 ```sh
 TEST_LIBS=y make test
 ```
 
-It is also possible to test shared libraries using `pytest`, in which case
-environment variable `LEAPP_TESTED_LIBRARY` with path of the shared library
-needs to be specified for _pytest_ to be able to import leapp modules.
-
+It is also possible to test shared libraries using `pytest`.
 To run tests for all shared libraries:
 
 ```sh
-LEAPP_TESTED_LIBRARY="$PWD/libraries" pytest -sv libraries/tests
+pytest {PATH_TO_SHARED_LIBS}
 ```
+
 
 To run tests for one specific module:
 
 ```sh
-LEAPP_TESTED_LIBRARY="$PWD/libraries" pytest -sv libraries/tests/test_my_library.py
+pytest libraries/tests/test_my_library.py
 ```
 
 To run one specific test of module:
 
 ```sh
-LEAPP_TESTED_LIBRARY="$PWD/libraries" pytest -sv libraries/tests/test_my_library.py::test_something
+pytest libraries/tests/test_my_library.py::test_something
 ```


### PR DESCRIPTION
Update docs with regards to new functionality introduced in https://github.com/oamg/leapp-repository/pull/500 

- describe name conventions for test modules and actors libraries
- describe how to use pytest for the testing actor(s), library(ies) 

TODO:
- [ ] Merge only after https://github.com/oamg/leapp-repository/pull/500