### PR TITLE
Fix/empty answerfile

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -240,12 +240,14 @@ def upgrade(args):
         workflow.load_answers(answerfile_path, userchoices_path)
         workflow.run(context=context, skip_phases_until=skip_phases_until, skip_dialogs=True)
 
+    logger.info("Answerfile will be created at %s", answerfile_path)
+    workflow.save_answers(answerfile_path, userchoices_path)
     report_errors(workflow.errors)
     report_inhibitors(context)
     generate_report_files(context)
     report_files = get_cfg_files('report', cfg)
     log_files = get_cfg_files('logs', cfg)
-    report_info(report_files, log_files, fail=workflow.failure)
+    report_info(report_files, log_files, answerfile_path, fail=workflow.failure)
 
     if workflow.failure:
         sys.exit(1)

--- a/leapp/utils/workarounds/mp.py
+++ b/leapp/utils/workarounds/mp.py
@@ -16,7 +16,7 @@ def apply_workaround():
             super(FixedFinalize, self).__init__(*args, **kwargs)
             self._pid = os.getpid()
 
-        def __call__(self, *args, **kwargs):
+        def __call__(self, *args, **kwargs):    # pylint: disable=signature-differs
             if self._pid != os.getpid():
                 return None
             return super(FixedFinalize, self).__call__(*args, **kwargs)


### PR DESCRIPTION
With this MR, if running leapp upgrade, the answerfile created and stored (the same like in preupgrade) in order for a possible use in the next upgrade run.