### PR TITLE
Feature/skip actors discovery option

### DIFF
--- a/leapp/repository/__init__.py
+++ b/leapp/repository/__init__.py
@@ -112,7 +112,7 @@ class Repository(object):
 
         self._definitions.setdefault(kind, []).append(item)
 
-    def load(self, resolve=True, stage=None):
+    def load(self, resolve=True, stage=None, skip_actors_discovery=False):
         """
         Loads the repository resources
 
@@ -145,7 +145,7 @@ class Repository(object):
             sys.meta_path.append(LeappLibrariesFinder(module_prefix='leapp.libraries.common', paths=self.libraries))
             sys.meta_path.append(LeappLibrariesFinder(module_prefix='leapp.workflows.api', paths=self.apis))
 
-        if not stage or stage is _LoadStage.ACTORS:
+        if not stage or stage is _LoadStage.ACTORS and not skip_actors_discovery:
             self.log.debug("Running actor discovery")
             for actor in self.actors:
                 actor.discover()

--- a/leapp/repository/__init__.py
+++ b/leapp/repository/__init__.py
@@ -145,10 +145,11 @@ class Repository(object):
             sys.meta_path.append(LeappLibrariesFinder(module_prefix='leapp.libraries.common', paths=self.libraries))
             sys.meta_path.append(LeappLibrariesFinder(module_prefix='leapp.workflows.api', paths=self.apis))
 
-        if not stage or stage is _LoadStage.ACTORS and not skip_actors_discovery:
-            self.log.debug("Running actor discovery")
-            for actor in self.actors:
-                actor.discover()
+        if not skip_actors_discovery:
+            if not stage or stage is _LoadStage.ACTORS:
+                self.log.debug("Running actor discovery")
+                for actor in self.actors:
+                    actor.discover()
 
         if not stage or stage is _LoadStage.WORKFLOWS:
             self.log.debug("Loading workflow modules")

--- a/leapp/repository/manager.py
+++ b/leapp/repository/manager.py
@@ -77,12 +77,16 @@ class RepositoryManager(object):
         """
         return self._repos.get(repo_id, None)
 
-    def load(self, resolve=True):
+    def load(self, resolve=True, skip_actors_discovery=False):
         """
         Load all known repositories.
 
         :param resolve: Whether or not to perform the resolving of model references
         :type resolve: bool
+        :param skip_actors_discovery: specifies whether to skip discovery process of the actors
+            When we testing actors, we're directly injecting the actor context, so we don't
+            need to inject it during the repo loading. This option helps to solve this problem.
+        :type skip_actors_discovery: bool
         """
         for repo in self._repos.values():
             repo.load(resolve=False, stage=_LoadStage.INITIAL)
@@ -94,7 +98,7 @@ class RepositoryManager(object):
             repo.load(resolve=False, stage=_LoadStage.LIBRARIES)
 
         for repo in self._repos.values():
-            repo.load(resolve=False, stage=_LoadStage.ACTORS)
+            repo.load(resolve=False, stage=_LoadStage.ACTORS, skip_actors_discovery=skip_actors_discovery)
 
         for repo in self._repos.values():
             repo.load(resolve=False, stage=_LoadStage.WORKFLOWS)


### PR DESCRIPTION
The mechanism behind how we're testing actors assumes direct injection of the actor context with the help of actor.injected_context. This loads the actor context and testing of actor starts.

However, before the testing session, we also need to load the repo itself. The current implementation of this procedure also starts the process of discovering actors (also injection occurs) and we can't bypass it. This means we're doing it two times.

Considering that this procedure takes significant time, this MR introduces the possibility to skip discovering actors during loading the repo.