### PR TITLE
Introduction of the @deprecated decorator & integration into the workflow executions

### DIFF
--- a/docs/source/deprecation.md
+++ b/docs/source/deprecation.md
@@ -1,0 +1,136 @@
+## Deprecation
+
+To help with the deprecation process of entities in leapp, the leapp framework introduced a decorator `deprecated`
+which can be imported from `leapp.utils.deprecation`.
+
+This decorator will mark items as being deprecated and ensures that a deprecation warning is displayed if this item
+is being used.
+
+### Warning message display behaviour
+
+Warning messages are always shown after `snactor` executions via `snactor run` or `snactor workflow run`.
+At the end of executions of `leapp upgrade` or `leapp preupgrade` the warnings are added as report entries with a
+developer audience. If the deprecation is less than 6 months old the severity is set to 'MEDIUM' if it is older than
+6 months the severity is set to 'HIGH'
+
+#### snactor warning message example
+
+```
+============================================================
+                 USE OF DEPRECATED ENTITIES
+============================================================
+
+Usage of deprecated function "deprecated_function" @ /Users/vfeenstr/devel/work/leapp/leapp/tests/data/deprecation-tests/actors/deprecationtests/actor.py:19
+Near:         deprecated_function()
+
+Reason: This function is no longer supported.
+------------------------------------------------------------
+Usage of deprecated Model "DeprecatedModel" @ /Users/vfeenstr/devel/work/leapp/leapp/tests/data/deprecation-tests/actors/deprecationtests/actor.py:20
+Near:         self.produce(DeprecatedModel())
+
+Reason: This model is deprecated - Please do not use it anymore
+------------------------------------------------------------
+Usage of deprecated class "DeprecatedNoInit" @ /Users/vfeenstr/devel/work/leapp/leapp/tests/data/deprecation-tests/actors/deprecationtests/actor.py:21
+Near:         DeprecatedNoInit()
+
+Reason: Deprecated class without __init__
+------------------------------------------------------------
+Usage of deprecated class "DeprecatedBaseNoInit" @ /Users/vfeenstr/devel/work/leapp/leapp/tests/data/deprecation-tests/actors/deprecationtests/actor.py:22
+Near:         DeprecatedNoInitDerived()
+
+Reason: Deprecated base class without __init__
+------------------------------------------------------------
+Usage of deprecated class "DeprecatedWithInit" @ /Users/vfeenstr/devel/work/leapp/leapp/tests/data/deprecation-tests/actors/deprecationtests/actor.py:23
+Near:         DeprecatedWithInit()
+
+Reason: Deprecated class with __init__
+------------------------------------------------------------
+
+============================================================
+             END OF USE OF DEPRECATED ENTITIES
+============================================================
+```
+
+#### leapp report example entries
+
+```
+----------------------------------------
+Risk Factor: medium
+Title: Usage of deprecated class "IsolatedActions" at /usr/share/leapp-repository/repositories/system_upgrade/el7toel8/libraries/repofileutils.py:38
+Summary: IsolatedActions are deprecated
+Since: 2020-01-02
+Location: /usr/share/leapp-repository/repositories/system_upgrade/el7toel8/libraries/repofileutils.py:38
+Near: def get_parsed_repofiles(context=mounting.NotIsolatedActions(base_dir='/')):
+
+----------------------------------------
+Risk Factor: medium
+Title: Usage of deprecated class "IsolatedActions" at /usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/scansubscriptionmanagerinfo/libraries/scanrhsm.py:8
+Summary: IsolatedActions are deprecated
+Since: 2020-01-02
+Location: /usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/scansubscriptionmanagerinfo/libraries/scanrhsm.py:8
+Near:     context = NotIsolatedActions(base_dir='/')
+
+----------------------------------------
+Risk Factor: medium
+Title: Usage of deprecated function "deprecated_method" at /usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/deprecationdemo/actor.py:21
+Summary: Deprecated for Demo!
+Since: 2020-06-17
+Location: /usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/deprecationdemo/actor.py:21
+Near:         self.deprecated_method()
+
+----------------------------------------
+```
+
+## Usage examples of @deprecated
+
+### Functions
+
+```python
+...
+from leapp.utils.deprecation import deprecated
+
+
+@deprecated(since='2020-06-20', message='This function has been deprecated!')
+def some_deprecated_function(a, b, c):
+    pass
+```
+
+### Models
+
+```python
+...
+from leapp.utils.deprecation import deprecated
+
+
+@deprecated(since='2020-06-20', message='This model has been deprecated!')
+class MyModel(Model):
+    topic = SomeTopic
+    some_field = fields.String()
+```
+
+### Classes
+
+```python
+...
+from leapp.utils.deprecation import deprecated
+
+
+@deprecated(since='2020-06-20', message='This class has been deprecated!')
+class MyClass(object):
+    pass
+
+
+# NOTE: Here we need to offset the stacklevel to get the report of the usage not in the derived class constructor
+# but where the derived class has been created.
+# How many levels you need, you will have to test, it depends on if you use the builtin __init__ methods or not,
+# however it gives you the ability to go up the stack until you reach the position you need to.
+@deprecated(since='2020-06-20', message='This class has been deprecated!', stack_level_offset=1)
+class ABaseClass(object):
+    def __init__(self):
+        pass
+
+
+class ADerivedClass(ABaseClass)
+    def __init__(self):
+        super(ADerivedClass, self).__init__()
+```

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -16,3 +16,4 @@ Tutorials
     workflow-apis
     unit-testing
     debugging
+    deprecation

--- a/leapp/snactor/commands/run.py
+++ b/leapp/snactor/commands/run.py
@@ -1,6 +1,8 @@
-from importlib import import_module
+import datetime
 import json
+import os
 import sys
+from importlib import import_module
 
 from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
@@ -8,7 +10,7 @@ from leapp.messaging.inprocess import InProcessMessaging
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.snactor.context import with_snactor_context
 from leapp.utils.clicmd import command, command_arg, command_opt
-from leapp.utils.output import beautify_actor_exception, report_errors
+from leapp.utils.output import beautify_actor_exception, report_deprecations, report_errors
 from leapp.utils.repository import find_repository_basedir, requires_repository
 
 _LONG_DESCRIPTION = '''
@@ -27,6 +29,7 @@ https://red.ht/leapp-docs
 @requires_repository
 @with_snactor_context
 def cli(args):
+    start = datetime.datetime.utcnow()
     log = configure_logger()
     basedir = find_repository_basedir('.')
     repository = find_and_scan_repositories(basedir, include_locals=True)
@@ -53,6 +56,7 @@ def cli(args):
             raise
 
     report_errors(messaging.errors())
+    report_deprecations(os.getenv('LEAPP_EXECUTION_ID'), start=start)
 
     if failure or messaging.errors():
         sys.exit(1)

--- a/leapp/snactor/commands/workflow/run.py
+++ b/leapp/snactor/commands/workflow/run.py
@@ -1,16 +1,17 @@
 from __future__ import print_function
+
+import datetime
 import os
 import sys
 
-from leapp.exceptions import LeappError, CommandError
+from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.snactor.commands.workflow import workflow
 from leapp.snactor.context import with_snactor_context
 from leapp.utils.clicmd import command_arg, command_opt
-from leapp.utils.output import report_errors, beautify_actor_exception
-from leapp.utils.repository import requires_repository, find_repository_basedir
-
+from leapp.utils.output import beautify_actor_exception, report_deprecations, report_errors
+from leapp.utils.repository import find_repository_basedir, requires_repository
 
 _LONG_DESCRIPTION = '''
 Executes the given workflow.
@@ -37,6 +38,7 @@ https://red.ht/leapp-docs
 @requires_repository
 def cli(params):
     def impl(context=None):
+        start = datetime.datetime.utcnow()
         configure_logger()
         repository = find_and_scan_repositories(find_repository_basedir('.'), include_locals=True)
         try:
@@ -60,6 +62,7 @@ def cli(params):
             instance.run(context=context, until_phase=params.until_phase, until_actor=params.until_actor)
 
         report_errors(instance.errors)
+        report_deprecations(os.getenv('LEAPP_EXECUTION_ID'), start=start)
 
         if instance.failure:
             sys.exit(1)

--- a/leapp/utils/audit/__init__.py
+++ b/leapp/utils/audit/__init__.py
@@ -133,6 +133,7 @@ class Host(Storable):
     """
     Host information
     """
+
     def __init__(self, context=None, hostname=None):
         self.context = context
         self.hostname = hostname
@@ -159,6 +160,7 @@ class MessageData(Storable):
     """
     Message data
     """
+
     def __init__(self, data=None, hash_id=None):
         """
         :param data: Message payload
@@ -292,9 +294,15 @@ def get_audit_entry(event, context):
                 audit.id          AS id,
                 audit.stamp       AS stamp,
                 audit.data        AS data,
-                audit.context     AS context
+                audit.context     AS context,
+                data_source.actor AS actor,
+                host.hostname     AS hostname
               FROM
                 audit
+              JOIN
+                data_source ON data_source.id = audit.data_source_id
+              JOIN
+                host ON data_source.host_id = host.id
               WHERE
                 audit.context = ? AND audit.event = ?
               ORDER BY stamp ASC;

--- a/leapp/utils/deprecation.py
+++ b/leapp/utils/deprecation.py
@@ -1,0 +1,113 @@
+import datetime
+import functools
+import inspect
+import warnings
+from collections import namedtuple
+
+from leapp.models import Model
+
+
+_suppressed_deprecations = set()
+
+
+def suppress_deprecation(*suppressed_items):
+    """
+    Decorator to suppress deprecation warnings during the execution of the decorated entity.
+
+    This can be used directly on Actor classes OR functions. This relies on the fact that a class has a `process`
+    method, if the method does not exist, this may cause mayhem.
+
+    :param suppressed_items: Variable number of arguments each for entities to suppress the deprecation warnings for.
+    """
+    def decorator(item):
+        target_item = item
+        if inspect.isclass(item):
+            target_item = getattr(item, 'process', None)
+
+        @functools.wraps(target_item)
+        def process_wrapper(*args, **kwargs):
+            for suppressed in suppressed_items:
+                _suppressed_deprecations.add(suppressed)
+            try:
+                return target_item(*args, **kwargs)
+            finally:
+                for suppressed in suppressed_items:
+                    _suppressed_deprecations.remove(suppressed)
+        if inspect.isclass(item):
+            item.process = process_wrapper
+            return item
+        return process_wrapper
+    return decorator
+
+
+class _LeappDeprecationWarning(DeprecationWarning):
+    since = None
+    message = None
+
+
+def deprecated(since, message, stack_level_offset=0):
+    """
+    `deprecated` is a decorator for items to mark them as being deprecated
+
+    :param message: Information about why it was deprecated and potentially a pointer for an alternative
+    :param since: Date since when this item is marked deprecated
+    :type since: str in the form YYYY-MM-DD (strftime format: %Y-%m-%d)
+    :param stack_level_offset: Number of stack levels to report above the reported stack level. This is mainly useful,
+                               when using the decorator on a base class and ensuring the derived classes are going to
+                               report deprecation usage at the place the derived class was intantiated and not in the
+                               constructor of the derived class.
+    :type stack_level_offset: int
+    """
+    # Ensure %Y-%m-%d format otherwise it will raise a Value error
+    since = datetime.datetime.strptime(since, "%Y-%m-%d").date().strftime("%Y-%m-%d")
+
+    def decorator(item):
+        kind = 'function'
+        if inspect.isclass(item):
+            if issubclass(item, Model):
+                kind = 'Model'
+            else:
+                kind = 'class'
+
+        _since = since
+
+        class _DeprecationWarningContext(_LeappDeprecationWarning):
+            since = _since
+            msg = message
+
+        item.__deprecation__ = namedtuple('Deprecation', ('since', 'message'))(since=since, message=message)
+
+        # Storing the result so we can suppress later the actual thing.
+        # In case it is a class, the class itself is returned, so no problem here, however if we want to suppress
+        # the usage of a function, we need to check against the wrapper
+        result = None
+
+        def do_warn():
+            if result in _suppressed_deprecations:
+                return
+
+            # Inserts temporarily a filter rule
+            warnings.simplefilter(action='always', category=_LeappDeprecationWarning)
+            # Issue warning
+            warnings.warn(message='Usage of deprecated {kind} "{name}"'.format(
+                kind=kind, name=item.__name__), category=_DeprecationWarningContext, stacklevel=3 + stack_level_offset)
+            # Pops temporarily inserted filtration rule
+            warnings.filters.pop(0)
+
+        if inspect.isclass(item):
+            old_init = item.__init__
+
+            @functools.wraps(item.__init__, assigned=('__name__', '__doc__'))
+            def wrapper(*args, **kwargs):
+                do_warn()
+                return old_init(*args, **kwargs)
+            item.__init__ = wrapper
+            result = item
+        else:
+            @functools.wraps(item)
+            def wrapper(*args, **kwargs):
+                do_warn()
+                return item(*args, **kwargs)
+            result = wrapper
+        return result
+    return decorator

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 1.2
+%global framework_version 1.3
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,5 +3,5 @@
 mock
 pytest==3.6.4
 pytest-flake8
-pytest-cov
+pytest-cov==2.9.0
 pytest-pylint==0.14.1

--- a/tests/data/deprecation-tests/.leapp/info
+++ b/tests/data/deprecation-tests/.leapp/info
@@ -1,0 +1,1 @@
+{"name": "deprecation-tests", "id": "8165d9db-9ed5-4135-87ed-64c61997b7c1"}

--- a/tests/data/deprecation-tests/.leapp/leapp.conf
+++ b/tests/data/deprecation-tests/.leapp/leapp.conf
@@ -1,0 +1,6 @@
+
+[repositories]
+repo_path=${repository:root_dir}
+
+[database]
+path=${repository:state_dir}/leapp.db

--- a/tests/data/deprecation-tests/actors/deprecationtests/actor.py
+++ b/tests/data/deprecation-tests/actors/deprecationtests/actor.py
@@ -1,0 +1,44 @@
+from leapp.actors import Actor
+from leapp.libraries.common.deprecation import (DeprecatedNoInit, DeprecatedNoInitDerived, DeprecatedWithInit,
+                                                DeprecatedWithInitDerived, deprecated_function)
+from leapp.models import DeprecatedModel, SuppressedDeprecatedModel
+from leapp.tags import DeprecationPhaseTag, DeprecationWorkflowTag
+from leapp.utils.deprecation import suppress_deprecation, deprecated
+
+
+def whatever(f):
+    def wrapper():
+        f()
+    return wrapper
+
+
+@deprecated(since='2011-11-11', message='never to be seen')
+@whatever
+def foobar():
+    pass
+
+
+@suppress_deprecation(SuppressedDeprecatedModel, foobar)
+def test_fun(self):
+    self.produce(SuppressedDeprecatedModel())
+    foobar()
+
+
+class DeprecationTests(Actor):
+    """
+    No documentation has been provided for the deprecation_tests actor.
+    """
+
+    name = 'deprecation_tests'
+    consumes = ()
+    produces = (DeprecatedModel, SuppressedDeprecatedModel)
+    tags = (DeprecationWorkflowTag, DeprecationPhaseTag)
+
+    def process(self):
+        test_fun(self)
+        deprecated_function()
+        self.produce(DeprecatedModel())
+        DeprecatedNoInit()
+        DeprecatedNoInitDerived()
+        DeprecatedWithInit()
+        DeprecatedWithInitDerived()

--- a/tests/data/deprecation-tests/libraries/deprecation.py
+++ b/tests/data/deprecation-tests/libraries/deprecation.py
@@ -1,0 +1,36 @@
+from leapp.utils.deprecation import deprecated
+
+
+@deprecated('2010-01-01', 'Deprecated class without __init__')
+class DeprecatedNoInit(object):
+    pass
+
+
+@deprecated('2010-01-01', 'Deprecated class with __init__')
+class DeprecatedWithInit(object):
+    pass
+
+
+@deprecated('2010-01-01', 'Deprecated base class without __init__')
+class DeprecatedBaseNoInit(object):
+    pass
+
+
+class DeprecatedNoInitDerived(DeprecatedBaseNoInit):
+    pass
+
+
+@deprecated('2010-01-01', 'Deprecated base class with __init__')
+class DeprecatedBaseWithInit(object):
+    def __init__(self):
+        pass
+
+
+class DeprecatedWithInitDerived(DeprecatedBaseWithInit):
+    def __init__(self):
+        pass
+
+
+@deprecated('2010-01-01', 'This function is no longer supported.')
+def deprecated_function():
+    pass

--- a/tests/data/deprecation-tests/models/deprecatedmodel.py
+++ b/tests/data/deprecation-tests/models/deprecatedmodel.py
@@ -1,0 +1,13 @@
+from leapp.models import Model, fields
+from leapp.topics import DeprecationTopic
+from leapp.utils.deprecation import deprecated
+
+
+@deprecated('2010-01-01', 'This model is deprecated - Please do not use it anymore')
+class DeprecatedModel(Model):
+    topic = DeprecationTopic
+
+
+@deprecated('2010-01-01', 'This model is deprecated - This should not be warned about')
+class SuppressedDeprecatedModel(Model):
+    topic = DeprecationTopic

--- a/tests/data/deprecation-tests/tags/deprecationphasetag.py
+++ b/tests/data/deprecation-tests/tags/deprecationphasetag.py
@@ -1,0 +1,5 @@
+from leapp.tags import Tag
+
+
+class DeprecationPhaseTag(Tag):
+    name = 'deprecation_phase_tag'

--- a/tests/data/deprecation-tests/tags/deprecationworkflow.py
+++ b/tests/data/deprecation-tests/tags/deprecationworkflow.py
@@ -1,0 +1,5 @@
+from leapp.tags import Tag
+
+
+class DeprecationWorkflowTag(Tag):
+    name = 'deprecation_workflow'

--- a/tests/data/deprecation-tests/topics/deprecation.py
+++ b/tests/data/deprecation-tests/topics/deprecation.py
@@ -1,0 +1,5 @@
+from leapp.topics import Topic
+
+
+class DeprecationTopic(Topic):
+    name = 'deprecation'

--- a/tests/data/deprecation-tests/workflows/deprecation_workflow.py
+++ b/tests/data/deprecation-tests/workflows/deprecation_workflow.py
@@ -1,0 +1,20 @@
+from leapp.workflows import Workflow
+from leapp.workflows.phases import Phase
+from leapp.workflows.flags import Flags
+from leapp.workflows.tagfilters import TagFilter
+from leapp.workflows.policies import Policies
+from leapp.tags import DeprecationWorkflowTag, DeprecationPhaseTag
+
+
+class DeprecationWorkflow(Workflow):
+    name = 'DeprecationWorkflow'
+    tag = DeprecationWorkflowTag
+    short_name = 'deprecation_workflow'
+    description = '''No description has been provided for the DeprecationWorkflow workflow.'''
+
+    class PhaseName(Phase):
+        name = 'deprecation_phase'
+        filter = TagFilter(DeprecationPhaseTag)
+        policies = Policies(Policies.Errors.FailPhase,
+                            Policies.Retry.Phase)
+        flags = Flags()


### PR DESCRIPTION
Introduction of the @deprecated decorator

This patch introduces the @deprecated Decorator allowing it to be used
for Models and functions/methods anywhere in the code.
The code makes use of the python warnings library and extends the usage
around this by allowing to pass the information since when the entity is
deprecated and pass a reason for the deprecation (e.g. replacement by
something else)

Log deprecation warnings to the audit db

Additionally in this patch logging of deprecations to the audit database
is introduced.
It will create a new event type 'deprecation' and logs details about
location and place.

Start reporting deprecation usages

On top of it this patch adds deprecation usages to the reports.
It will receive the items from the audit database.
If an item is deprecated for more than 6 month the severity of
the report entry is set to HIGH otherwise it is set to MEDIUM.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>