### PR TITLE
Allow running as a not a root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
 install:
   - if [ ! -z "$CONTAINER" ]; then make install-container-test CONTAINER=$CONTAINER; fi
   - if [ -z "$CONTAINER" ]; then make install-test; fi
-  - if [ -z "$CONTAINER" ]; then pip install --editable .; fi
 
 script:
   - if [ ! -z "$CONTAINER" ]; then make container-test; else make test; fi

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+-e .
 
 mock
 pytest==3.6.4


### PR DESCRIPTION
Now if you're not a root, then the venv
automatically installed with requred dependencies

Also requirements-tests.txt updated to install leapp
in editable mode

fixes #646 

Now if you're not a root, it is enough to do:
`make install-test && make test`