### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,6 +1,6 @@
 from leapp.utils.workarounds import apply_workarounds
 
-VERSION = "0.10.0"
+VERSION = "0.11.0"
 FULL_VERSION = VERSION
 
 apply_workarounds()

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,4 +1,4 @@
-.TH LEAPP "1" "2020-04-16" "leapp 0.10.0" "User Commands"
+.TH LEAPP "1" "2020-04-16" "leapp 0.11.0" "User Commands"
 
 .SH NAME
 leapp \- command line interface for upgrades between major OS versions

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,4 +1,4 @@
-.TH SNACTOR "1" "2020-04-16" "snactor 0.10.0" "User Commands"
+.TH SNACTOR "1" "2020-04-16" "snactor 0.11.0" "User Commands"
 
 .SH NAME
 snactor \- development and repository management tool for leapp

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -32,7 +32,7 @@
 %endif
 
 Name:       leapp
-Version:    0.10.0
+Version:    0.11.0
 Release:    1%{?dist}
 Summary:    OS & Application modernization framework
 


### PR DESCRIPTION
## Packaging
- Bump leapp-framework capability to 1.3

## Framework
### Fixes
- Preserve verbose/debug options during the whole upgrade workflow (#625)
- Print the informative error block to the STDOUT instead of STDERR (#623)

### Enhancements
- Added new reporting tags: `PUBLIC_CLOUD` and `RHUI` (#650)
- Added the possibility to skip actor discovery to improve performance of tests when an actor context is injected directly (#638)
- Introduced the `deprecated` and `suppress_deprecation` decorators to support the deprecation process (#640, #653)
- Store dialog answers in the leapp.db (#651)

### Known issues
- The `suppress_deprecation` decorator causes a traceback in certain cases

## Leapp
### Enhancements
- Updated and improved man pages (#633)

## Snactor
### Fixes
- Raising a missing exception with tests failing under py3 (#647)

### Enhancements
- Added the --actor-config option to `snactor run` to specify a workflow configuration model that should be consumed by actors (#627)

## Leapp Standard Library
### Enhancements
- The `call` function has been improved to be working on MacOS (#634)
