### PR TITLE
manpage: Fix typo (enable-repo)

### DIFF
--- a/man/leapp.1
+++ b/man/leapp.1
@@ -45,11 +45,11 @@ leapp \- command line interface for upgrades between major OS versions
     Print all but debug log messages (info, warning, error, critical) to stderr.
     By default only error and critical level messages are printed.
 
-\fB--enable-repo\fR <\fIrepoid\fR>
+\fB--enablerepo\fR <\fIrepoid\fR>
     Enable specified repository. Can be used multiple times.
 
 \fB--no-rhsm\fR
-    Skip actions that use Red Hat Subscription Manager. You'll also have to supply custom repositories through \fB--enable-repo\fR (see above).
+    Skip actions that use Red Hat Subscription Manager. You'll also have to supply custom repositories through \fB--enablerepo\fR (see above).
 
 \fB--whitelist-experimental\fR <\fIActorName\fR>
     Enable an experimental actor. Can be used multiple times.


### PR DESCRIPTION
A mistake crept in.