### PR TITLE
pylint: Disable checks introduced in pylint 2.6

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -31,7 +31,9 @@ disable=
  too-many-public-methods,
  too-many-statements,
 # new for python3 version of pylint
- useless-object-inheritance
+ useless-object-inheritance,
+ super-with-arguments,  # required in python 2
+ raise-missing-from,  # no 'raise from' in python 2
 
 [FORMAT]
 # Maximum number of characters on a single line.


### PR DESCRIPTION
pylint 2.6 was released on 2020-08-20 and introduced two new checks
which we cannot use due to Python 2:
  - `super-with-arguments` (R1725)
  - `raise-missing-from` (W0707)

Release notes: http://pylint.pycqa.org/en/latest/whatsnew/2.6.html

Virtually identical to https://github.com/oamg/leapp-repository/pull/582.