### PR TITLE
Fix deprecation

### DIFF
--- a/leapp/utils/deprecation.py
+++ b/leapp/utils/deprecation.py
@@ -23,6 +23,13 @@ def suppress_deprecation(*suppressed_items):
         target_item = item
         if inspect.isclass(item):
             target_item = getattr(item, 'process', None)
+            if target_item is None:
+                raise ValueError(
+                    'The suppress_deprecation decorator has been used on a class which'
+                    ' does not contain the process method. The decorator can be used'
+                    ' only for classes with that method (e.g. classes derived from Actor).'
+                    ' Use the decorator on the affected methods instead of the current class.'
+                )
 
         @functools.wraps(target_item)
         def process_wrapper(*args, **kwargs):

--- a/tests/data/deprecation-tests/actors/deprecationtests/actor.py
+++ b/tests/data/deprecation-tests/actors/deprecationtests/actor.py
@@ -24,6 +24,18 @@ def test_fun(self):
     foobar()
 
 
+@suppress_deprecation(SuppressedDeprecatedModel)
+def test_fun1(self):
+    self.produce(SuppressedDeprecatedModel())
+    test_fun(self)
+
+
+@suppress_deprecation(SuppressedDeprecatedModel)
+def test_fun2(self):
+    test_fun(self)
+    self.produce(SuppressedDeprecatedModel())
+
+
 class DeprecationTests(Actor):
     """
     No documentation has been provided for the deprecation_tests actor.
@@ -36,6 +48,8 @@ class DeprecationTests(Actor):
 
     def process(self):
         test_fun(self)
+        test_fun1(self)
+        test_fun2(self)
         deprecated_function()
         self.produce(DeprecatedModel())
         DeprecatedNoInit()


### PR DESCRIPTION
Two fixes:
1. The suppress_deprecation decorator cannot be used on every class. It's expected a class has the process method. Instead of confusing simple crash, raise an exception with a meaningful message when decorator is used on a class without the process method.

1. Handle 'nested' suppress of deprecation
    
    Imagine case (pseudocode):
    ```pseudocode
      (Ddep is deprecated entity)
    
      @suppress_deprecation(Ddep)
      def fA():
          create Ddep
          fB()
    
      @suppress_deprecation(Ddep)
      def fB():
          create Ddep
    ```
    
    In such a case, apps crashed, because we store information about
    suppressed deprecation into the set. After you leave the fB function
    the Ddep entity is removed from the set and after end of fA function
    there is no way to remove it again - so the app crashes. This commit
    fixes the problem.

The first case is not covered by tests. The second one it is.