### PR TITLE
Fix report deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ leapp/utils/schemas.py
 res/schema/schemas.py
 .vscode/
 leapp.db
+# do not ignore the directory with tests...
+!tests/scripts/

--- a/leapp/utils/report.py
+++ b/leapp/utils/report.py
@@ -13,7 +13,8 @@ def _create_reports_from_deprecations(context_id):
         data = json.loads(entry['data'])
 
         # Drop duplicates
-        data_hash = hashlib.sha256(json.dumps(data, sort_keys=True)).hexdigest()
+        _data_dump = json.dumps(data, sort_keys=True).encode('utf-8')
+        data_hash = hashlib.sha256(_data_dump).hexdigest()
         if data_hash in cache:
             continue
         cache.add(data_hash)

--- a/tests/scripts/test_utils_report.py
+++ b/tests/scripts/test_utils_report.py
@@ -1,0 +1,84 @@
+from collections import namedtuple
+import datetime
+import json
+
+import pytest
+
+import leapp.utils.report
+
+_CONTEXT = 'some_str'
+curr_date = datetime.datetime.today()
+
+
+def _create_entry(data, event='deprecation', context=_CONTEXT):
+    return {
+        'id': '1',
+        'stamp': '2020-09-11T15:56:23.767457Z',
+        'actor': 'actor',
+        'hostname': 'hostname',
+        'data': json.dumps(data),
+        'context': context,
+        'event': event,
+    }
+
+
+_AUDIT_DATA = (
+    # first two entries should be filtered out
+    _create_entry(context='ignore123', data={}),
+    _create_entry(event='something', data={}),
+    _create_entry({
+        'message': 'Usage of deprecated Model "DeprecatedModel"',
+        'filename': '/etc/leapp/repos.d/system_upgrade/el7toel8/actors/fooactor/actor.py',
+        'line': '        self.produce(DeprecatedModel(foo=bar))\n',
+        'lineno': 51,
+        'since': curr_date.strftime('%Y-%m-%d'),
+        'reason': 'The DeprecatedModel has been deprecated.',
+    }),
+    # this is one is duplicate of the previous one
+    _create_entry({
+        'message': 'Usage of deprecated Model "DeprecatedModel"',
+        'filename': '/etc/leapp/repos.d/system_upgrade/el7toel8/actors/fooactor/actor.py',
+        'line': '        self.produce(DeprecatedModel(foo=bar))\n',
+        'lineno': 51,
+        'since': curr_date.strftime('%Y-%m-%d'),
+        'reason': 'The DeprecatedModel has been deprecated.',
+    }),
+    _create_entry({
+        'message': 'Usage of deprecated Model "DetonatedModel"',
+        'filename': '/etc/leapp/repos.d/system_upgrade/el7toel8/actors/fooactor/actor.py',
+        'line': '        self.produce(DetonatedModel(foo=bar))\n',
+        'lineno': 51,
+        'since': curr_date.strftime('%Y-%m-%d'),
+        'reason': 'The DetonatedModel has been deprecated.',
+    }),
+    # to have at least one old entry
+    _create_entry({
+        'message': 'Usage of deprecated Model "AModel"',
+        'filename': '/etc/leapp/repos.d/system_upgrade/el7toel8/actors/fooactor/actor.py',
+        'line': '        self.produce(Amodel(foo=bar))\n',
+        'lineno': 51,
+        'since': '2018-01-01',
+        'reason': 'The Amodel has been deprecated.',
+    }),
+)
+
+
+def mocked_get_audit_entry(event, context):
+    return (entry for entry in _AUDIT_DATA if entry['context'] == context and entry['event'] == event)
+
+
+def test_create_report_from_deprecations(monkeypatch):
+    monkeypatch.setattr(leapp.utils.report, 'get_audit_entry', mocked_get_audit_entry)
+
+    reports = leapp.utils.report._create_reports_from_deprecations(_CONTEXT)
+    # no duplicates and only deprecated messages for the given context
+    assert len(reports) == len(_AUDIT_DATA) - 3
+
+    for report in reports:
+        assert 'Usage of deprecated Model' in report['title']
+        assert report['audience'] == 'developer'
+        assert report['severity'] in ('high', 'medium')
+    assert len([i for i in reports if i['severity'] == 'high']) == 1
+
+    reports = leapp.utils.report._create_reports_from_deprecations('non-existing-context')
+    assert not reports


### PR DESCRIPTION
The conversion of deprecation messages to reports was broken on Python3 because `haslib.sha256` requires byte string instead of Unicode (missing `.encode(utf-8)`). Added couple of tests to cover this part of code.

Also updated the .gitignore file so the `tests/scripts` directory is not ignored anymore.