### PR TITLE
Add a stable report identifier

### DIFF
--- a/leapp/dialogs/dialog.py
+++ b/leapp/dialogs/dialog.py
@@ -18,7 +18,7 @@ class Dialog(object):
         address values.
     """
 
-    def __init__(self, scope, reason, title=None, components=None):
+    def __init__(self, scope, reason, title=None, components=None, key=None):
         """
 
         :param scope: Unique scope identifier for the data to be stored in the answer files. Scope + component key
@@ -30,11 +30,14 @@ class Dialog(object):
         :type title: str
         :param components: Components to display in the given order in the dialog
         :type components: tuple(leapp.dialogs.components.Component)
+        :param key: Key to appear in the dialog-related report entry
+        :type key: str
         """
         self.components = components or self.components
         self.title = title
         self.scope = scope
         self.reason = reason
+        self.key = key
         self._store = None
         self._min_label_width = None
 

--- a/leapp/messaging/__init__.py
+++ b/leapp/messaging/__init__.py
@@ -157,7 +157,11 @@ class BaseMessaging(object):
         userchoices = dialog.get_answers(self._answers)
         if not userchoices:
             # produce DialogModel messages for all the dialogs that don't have answers in answerfile
-            self.produce(DialogModel(actor=actor.name, answerfile_sections=dialog.answerfile_sections), actor)
+            stable_key = dialog.key if dialog.key else hashlib.sha1(
+                ','.join(sorted(dialog.answerfile_sections.keys())).encode('utf-8')).hexdigest()
+            self.produce(DialogModel(actor=actor.name,
+                                     answerfile_sections=dialog.answerfile_sections,
+                                     key=stable_key), actor)
         else:
             # update dialogs with answers from answerfile. That is necessary for proper answerfile generation
             for component, value in userchoices.items():

--- a/leapp/models/__init__.py
+++ b/leapp/models/__init__.py
@@ -156,6 +156,7 @@ class DialogModel(Model):
     answerfile_sections = fields.JSON()
     actor = fields.String()
     details = fields.Nullable(fields.String())
+    key = fields.Nullable(fields.String())
 
 
 def get_models():

--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -133,7 +133,7 @@ class Key(BasePrimitive):
     name = 'key'
 
     def __init__(self, uuid):
-        self._value = uuid
+        self._value = str(uuid)
 
 
 class Tags(BasePrimitive):
@@ -299,15 +299,19 @@ def _check_stable_key(entries, raise_if_undefined=False):
         if entry:
             return entry._value
 
-    if _find_entry(Key):
-        # Key is already there, nothing to do
+    logger = configure_logger()
+    key = _find_entry(Key)
+    if key is not None:
+        # Key is already there, check that it's not an empty string
+        if not key.strip():
+            logger.error('An empty string is specified as Key')
+            raise ValueError('Key can not be an empty string.')
         return
 
     if raise_if_undefined:
         raise ValueError('Stable Key report entry with specified unique value not provided')
 
     # No Key found - let's generate one!
-    logger = configure_logger()
     key_str = u'{severity}:{audience}:{title}'.format(severity=_find_entry(Severity),
                                                       audience=_find_entry(Audience),
                                                       title=_find_entry(Title))

--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import hashlib
 import os
+import six
 
 from leapp.compat import string_types
 from leapp.logger import configure_logger
@@ -134,7 +135,7 @@ class Key(BasePrimitive):
 
     def __init__(self, uuid):
         # uuid is allowed to be string or unicode only, checking in py2/py3 friendly mode
-        if not isinstance(uuid, unicode) and not isinstance(uuid, str):
+        if not isinstance(uuid, six.string_types):
             raise ValueError('Key value should be a string.')
 
         self._value = uuid

--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -133,8 +133,10 @@ class Key(BasePrimitive):
     name = 'key'
 
     def __init__(self, uuid):
-        if not isinstance(uuid, str):
+        # uuid is allowed to be string or unicode only, checking in py2/py3 friendly mode
+        if not isinstance(uuid, unicode) and not isinstance(uuid, str):
             raise ValueError('Key value should be a string.')
+
         self._value = uuid
 
 

--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -133,7 +133,9 @@ class Key(BasePrimitive):
     name = 'key'
 
     def __init__(self, uuid):
-        self._value = str(uuid)
+        if not isinstance(uuid, str):
+            raise ValueError('Key value should be a string.')
+        self._value = uuid
 
 
 class Tags(BasePrimitive):

--- a/leapp/utils/report.py
+++ b/leapp/utils/report.py
@@ -100,6 +100,7 @@ def generate_report_file(messages_to_report, context, path):
                 remediation = Remediation.from_dict(message.get('detail', {}))
                 if remediation:
                     f.write('Remediation: {}\n'.format(remediation))
+                f.write('Key: {}\n'.format(message['key']))
                 f.write('-' * 40 + '\n')
     elif path.endswith(".json"):
         with open(path, 'w') as f:

--- a/tests/scripts/test_reporting.py
+++ b/tests/scripts/test_reporting.py
@@ -8,6 +8,8 @@ from leapp.reporting import (
     _DEPRECATION_SEVERITY_THRESHOLD,
     create_report_from_deprecation,
     create_report_from_error,
+    _create_report_object,
+    Audience, Key, Title, Summary, Severity, RelatedResource
 )
 
 
@@ -103,6 +105,15 @@ def test_convert_from_error_to_report():
     assert report['title'] == 'The system is not registered or subscribed.'
     assert report['audience'] == 'sysadmin'
     assert report['summary'] == 'Some other info that should go to report summary'
+    # make sure key argument is there
+    error_dict_key_not_specified = {
+        'message': 'The system is not registered or subscribed.',
+        'time': '2019-11-19T05:13:04.447562Z',
+        'details': 'Some other info that should go to report summary',
+        'actor': 'verify_check_results',
+        'severity': 'error'}
+    report = create_report_from_error(error_dict_key_not_specified)
+    assert "key" in report
 
 
 def test_create_report_from_deprecation():
@@ -128,3 +139,53 @@ def test_create_report_from_deprecation():
         assert data['reason'] in report['summary']
         assert data['since'] in report['summary']
         assert data['line'] in report['summary']
+        # make sure key argument is there
+        assert 'key' in report
+
+
+def test_create_report_stable_key(monkeypatch):
+    report_entries1 = [Title('Some report title'), Summary('Some summary not used for dynamical key generation'),
+                       Audience('sysadmin')]
+    report_entries2 = [Title('Some report title'),
+                       Summary('Another summary not used for dynamical key generation'), Audience('sysadmin')]
+    report_entries_with_severity = [Title('Some report title'),
+                                    Summary('Another summary not used for dynamical key generation'),
+                                    Severity('high')]
+    report_entries_with_audience = [Title('Some report title'),
+                                    Summary('Another summary not used for dynamical key generation'),
+                                    Audience('developer')]
+    report_entries_fixed_key = [Title('Some report title'), Summary('Different summary'), Key('42')]
+    report_entries_dialog1 = [Title('Some report title'), RelatedResource('dialog', 'unanswered_section'),
+                              Audience('sysadmin'), Summary('Summary')]
+    report_entries_dialog_key_set = [Title('Some report title'), RelatedResource('dialog', 'unanswered_section'),
+                                     RelatedResource('dialog', 'another_unanswered_section'), Audience('sysadmin'),
+                                     Summary('Summary'), Key('dialogkey42')]
+    report1 = _create_report_object(report_entries1)
+    report2 = _create_report_object(report_entries2)
+    report_with_severity = _create_report_object(report_entries_with_severity)
+    report_with_audience = _create_report_object(report_entries_with_audience)
+    report_fixed_key = _create_report_object(report_entries_fixed_key)
+    report_dialog1 = _create_report_object(report_entries_dialog1)
+    report_dialog_key_set = _create_report_object(report_entries_dialog_key_set)
+    # check that all reports have key field
+    for report in [report1, report2, report_with_severity, report_with_audience, report_fixed_key]:
+        assert "key" in report.report
+    # check that reports with same title but different summary have same dynamically generated key
+    assert report1.report["key"] == report2.report["key"]
+    # check that entries different in severity only will have different generated keys
+    assert report2.report["severity"] != report_with_severity.report["severity"]
+    assert report2.report["key"] != report_with_severity.report["key"]
+    # check that entries different in audience only will have different generated keys
+    assert report2.report["audience"] != report_with_audience.report["audience"]
+    assert report2.report["key"] != report_with_audience.report["key"]
+    # check that key from provided Key entry is taken
+    assert report_fixed_key.report["key"] == "42"
+    # check that specific dialog related resources are not considered in key generation
+    assert report_dialog1.report["key"] == report1.report["key"]
+    # check that providing a key for the dialog report is a solution
+    assert report_dialog1.report["key"] != report_dialog_key_set.report["key"]
+    assert report_dialog_key_set.report["key"] == "dialogkey42"
+    # check that if LEAPP_DEVEL_FIXED_REPORT_KEY is set and there is no key in the report - a ValueError is raised
+    monkeypatch.setenv('LEAPP_DEVEL_FIXED_REPORT_KEY', '1')
+    with pytest.raises(ValueError):
+        _create_report_object([Title('A title'), Summary('A summary')])

--- a/tests/scripts/test_reporting.py
+++ b/tests/scripts/test_reporting.py
@@ -193,5 +193,8 @@ def test_create_report_stable_key(monkeypatch):
     monkeypatch.setenv('LEAPP_DEVEL_FIXED_REPORT_KEY', '1')
     with pytest.raises(ValueError):
         _create_report_object([Title('A title'), Summary('A summary')])
-    # check that integers as string parameters are converted to strings
-    assert Key(42)._value == Key("42")._value == "42"
+    # check that Key accepts string parameters only
+    for bad_uuid in [42, object(), 42.42]:
+        with pytest.raises(ValueError) as err:
+            Key(bad_uuid)
+        assert str(err.value) == 'Key value should be a string.'

--- a/tests/scripts/test_reporting.py
+++ b/tests/scripts/test_reporting.py
@@ -185,7 +185,13 @@ def test_create_report_stable_key(monkeypatch):
     # check that providing a key for the dialog report is a solution
     assert report_dialog1.report["key"] != report_dialog_key_set.report["key"]
     assert report_dialog_key_set.report["key"] == "dialogkey42"
+    # check that empty string can't serve as report Key
+    with pytest.raises(ValueError) as err:
+        _create_report_object([Title('A title'), Summary('A summary'), Key('')])
+    assert str(err.value) == 'Key can not be an empty string.'
     # check that if LEAPP_DEVEL_FIXED_REPORT_KEY is set and there is no key in the report - a ValueError is raised
     monkeypatch.setenv('LEAPP_DEVEL_FIXED_REPORT_KEY', '1')
     with pytest.raises(ValueError):
         _create_report_object([Title('A title'), Summary('A summary')])
+    # check that integers as string parameters are converted to strings
+    assert Key(42)._value == Key("42")._value == "42"


### PR DESCRIPTION
A 'key' field will be added to each report entry. Same report entries on different machines should have the same 'key' value.

From the user/contributor perspective the interface doesn't change, if the Key with the unique report key is not defined in the report entries passed to the create_report command, the framework will take care of stable identifiers by generating one from the required report fields or will raise a ValueError in case LEAPP_DEVEL_FIXED_REPORT_KEY environment
variable is defined.
This fallback behavior will be the last resort once all actors in the leapp-repository are updated.