### PR TITLE
Replace functools.wraps with six.wraps

### DIFF
--- a/leapp/utils/clicmd.py
+++ b/leapp/utils/clicmd.py
@@ -4,6 +4,8 @@ import sys
 
 from argparse import ArgumentParser, _SubParsersAction, RawDescriptionHelpFormatter
 
+import six
+
 from leapp.exceptions import CommandDefinitionError, UsageError, CommandError
 
 
@@ -277,7 +279,7 @@ def command(name, help='', description=None, parent=None):  # noqa; pylint: disa
 
 
 def _ensure_command(wrapped):
-    @functools.wraps(wrapped)
+    @six.wraps(wrapped)
     def wrapper(f):
         if not hasattr(f, 'command'):
             f.command = Command('')
@@ -324,4 +326,4 @@ def command_aware_wraps(f):
     additional = ()
     if hasattr(f, 'command'):
         additional = ('command',)
-    return functools.wraps(f, assigned=functools.WRAPPER_ASSIGNMENTS + additional)
+    return six.wraps(f, assigned=functools.WRAPPER_ASSIGNMENTS + additional)

--- a/leapp/utils/deprecation.py
+++ b/leapp/utils/deprecation.py
@@ -1,8 +1,9 @@
 import datetime
-import functools
 import inspect
 import warnings
 from collections import namedtuple
+
+import six
 
 from leapp.models import Model
 
@@ -31,7 +32,7 @@ def suppress_deprecation(*suppressed_items):
                     ' Use the decorator on the affected methods instead of the current class.'
                 )
 
-        @functools.wraps(target_item)
+        @six.wraps(target_item)
         def process_wrapper(*args, **kwargs):
             # we need to remove later just items that we add right now
             # added_items == new items we add now to ...
@@ -106,14 +107,14 @@ def deprecated(since, message, stack_level_offset=0):
         if inspect.isclass(item):
             old_init = item.__init__
 
-            @functools.wraps(item.__init__, assigned=('__name__', '__doc__'))
+            @six.wraps(item.__init__, assigned=('__name__', '__doc__'))
             def wrapper(*args, **kwargs):
                 do_warn()
                 return old_init(*args, **kwargs)
             item.__init__ = wrapper
             result = item
         else:
-            @functools.wraps(item)
+            @six.wraps(item)
             def wrapper(*args, **kwargs):
                 do_warn()
                 return item(*args, **kwargs)

--- a/tests/scripts/test_deprecation.py
+++ b/tests/scripts/test_deprecation.py
@@ -10,6 +10,7 @@ import pytest
 import leapp.utils.audit
 from leapp.messaging.inprocess import InProcessMessaging
 from leapp.repository.scan import scan_repo
+from leapp.utils.deprecation import suppress_deprecation, deprecated
 
 
 @pytest.fixture(scope='module')
@@ -34,3 +35,14 @@ def test_deprecations(repository):
     entries = [entry for entry in entries
                if datetime.datetime.strptime(entry['stamp'].rstrip('Z'), '%Y-%m-%dT%H:%M:%S.%f') > start]
     assert entries and len(entries) == 5
+
+
+# This is test to show the current suppress_deprecation limitation
+@deprecated(since='2011-11-11', message='never to be seen')
+def foobar():
+    pass
+
+
+@suppress_deprecation(foobar)
+def test_suppress_with_fixture(monkeypatch):
+    assert monkeypatch


### PR DESCRIPTION
Previously we have been using functools.wraps. However if any decorator
that uses functools.wraps is used, some code that relies on __wrapped__
being present, e.g. pytest, will fail on Python2. Switching to six.wraps
will solve this problem, as it introduces this change as well and solves
the missing __wrapped__ attribute.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>