### PR TITLE
Feature/add possibility to overwrite the name of venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON_VENV ?= python
-
+VENVNAME ?= tut
 CONFDIR=${DESTDIR}/etc/leapp
 LIBDIR=${DESTDIR}/var/lib/leapp
 
@@ -121,8 +121,8 @@ install-test:
 ifeq ($(shell id -u), 0)
 	pip install -r requirements-tests.txt
 else
-	virtualenv --python $(PYTHON_VENV) tut
-	. tut/bin/activate ; \
+	virtualenv --python $(PYTHON_VENV) $(VENVNAME)
+	. $(VENVNAME)/bin/activate ; \
 	pip install -r requirements-tests.txt
 endif
 
@@ -133,7 +133,7 @@ test:   lint
 ifeq ($(shell id -u), 0)
 	pytest -vv --cov-report term-missing --cov=leapp tests/scripts
 else
-	. tut/bin/activate ; \
+	. $(VENVNAME)/bin/activate ; \
 	pytest -vv --cov-report term-missing --cov=leapp tests/scripts
 endif
 
@@ -142,7 +142,7 @@ ifeq ($(shell id -u), 0)
 	pytest --cache-clear --pylint -m pylint leapp tests/scripts/*.py; \
 	pytest --cache-clear --flake8 -m flake8 leapp tests/scripts/*.py
 else
-	. tut/bin/activate ; \
+	. $(VENVNAME)/bin/activate ; \
 	pytest --cache-clear --pylint -m pylint leapp tests/scripts/*.py; \
 	pytest --cache-clear --flake8 -m flake8 leapp tests/scripts/*.py
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PYTHON_VENV ?= python
+
 CONFDIR=${DESTDIR}/etc/leapp
 LIBDIR=${DESTDIR}/var/lib/leapp
 
@@ -109,7 +111,7 @@ install:
 	install -m 0744 etc/leapp/leapp.conf ${CONFDIR}
 	install -m 0744 etc/leapp/logger.conf ${CONFDIR}
 	install -dm 0755 ${LIBDIR}
-	umask 177 && python -c "import sqlite3; sqlite3.connect('${LIBDIR}/audit.db').executescript(open('res/audit-layout.sql', 'r').read())"
+	umask 177 && $(PYTHON_VENV) -c "import sqlite3; sqlite3.connect('${LIBDIR}/audit.db').executescript(open('res/audit-layout.sql', 'r').read())"
 
 install-container-test:
 	docker pull ${CONTAINER}
@@ -119,7 +121,7 @@ install-test:
 ifeq ($(shell id -u), 0)
 	pip install -r requirements-tests.txt
 else
-	virtualenv --python /usr/bin/python tut
+	virtualenv --python $(PYTHON_VENV) tut
 	. tut/bin/activate ; \
 	pip install -r requirements-tests.txt
 endif


### PR DESCRIPTION
Ref https://github.com/oamg/leapp-repository/pull/613

Adds the same functionality as we did at https://github.com/oamg/leapp-repository/pull/613. However, also adds a possibility to overwrite the python executable by the PYTHON_VENV variable (because otherwise, the feature doesn't make sense).

I don't think the naming PYTHON_VENV is good for referring to python executable, however, this is how it is called inside the https://github.com/oamg/leapp-repository/blob/master/Makefile#L28, so I keep the same naming here.

This feature allows overwriting the venv name by passing the
VENVNAME environment variable.

If the variable is not provided then tut will be used as a default value.

With this feature, you can create multiple python envs for easy testing,
i.e.

PYTHON_VENV=python3 VENVNAME=.venv_py3 make install-test
PYTHON_VENV=python2 VENVNAME=.venv_py2 make install-test

this will create python2 and python3 environments