### PR TITLE
Draft: Add profiling to leapp and snactor

### DIFF
--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -1,5 +1,9 @@
 import os
 import socket
+# profiling
+import cProfile
+import pstats
+import six
 
 from leapp.utils.clicmd import command, command_opt
 from leapp.cli import upgrade
@@ -12,7 +16,18 @@ def cli(args): # noqa; pylint: disable=unused-argument
 
 
 def main():
+    profile_enabled = os.environ.get('LEAPP_CPROFILE', '0') == '1'
+    if profile_enabled:
+        pr = cProfile.Profile()
+        pr.enable()
     os.environ['LEAPP_HOSTNAME'] = socket.getfqdn()
     for cmd in [upgrade.list_runs, upgrade.preupgrade, upgrade.upgrade, upgrade.answer]:
         cli.command.add_sub(cmd.command)
     cli.command.execute('leapp version {}'.format(VERSION))
+    if profile_enabled:
+        pr.disable()
+        s = six.StringIO()
+        sortby = 'cumulative'
+        ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+        ps.print_stats()
+        print(s.getvalue())

--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -16,7 +16,8 @@ def cli(args): # noqa; pylint: disable=unused-argument
 
 
 def main():
-    profile_enabled = os.environ.get('LEAPP_CPROFILE', '0') == '1'
+    os.environ['LEAPP_CPROFILE'] = os.environ.get('LEAPP_CPROFILE', '0')
+    profile_enabled = os.environ['LEAPP_CPROFILE'] == '1'
     if profile_enabled:
         pr = cProfile.Profile()
         pr.enable()

--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -77,7 +77,8 @@ def cli(args):
 
 
 def main():
-    profile_enabled = os.environ.get('LEAPP_CPROFILE', '0') == '1'
+    os.environ['LEAPP_CPROFILE'] = os.environ.get('LEAPP_CPROFILE', '0')
+    profile_enabled = os.environ['LEAPP_CPROFILE'] == '1'
     if profile_enabled:
         pr = cProfile.Profile()
         pr.enable()

--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -1,17 +1,10 @@
 import os
 import pkgutil
 import socket
-
 # for profilling
 import cProfile
 import pstats
-try:
-    from StringIO import StringIO
-except ImportError:
-    # TODO: low possibility of the problem with encoding with Python3;
-    # # but it should not be so problematic in this case, so keeping now just
-    # # like that to keep it simple
-    from io import StringIO
+import six
 
 from leapp.utils.i18n import _  # noqa; pylint: disable=redefined-builtin
 from leapp.snactor import commands
@@ -93,7 +86,7 @@ def main():
     cli.command.execute(version=_('snactor version {}').format(VERSION))
     if profile_enabled:
         pr.disable()
-        s = StringIO()
+        s = six.StringIO()
         sortby = 'cumulative'
         ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
         ps.print_stats()

--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -93,7 +93,7 @@ def main():
     cli.command.execute(version=_('snactor version {}').format(VERSION))
     if profile_enabled:
         pr.disable()
-        s = StringIO.StringIO()
+        s = StringIO()
         sortby = 'cumulative'
         ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
         ps.print_stats()

--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -2,6 +2,17 @@ import os
 import pkgutil
 import socket
 
+# for profilling
+import cProfile
+import pstats
+try:
+    from StringIO import StringIO
+except ImportError:
+    # TODO: low possibility of the problem with encoding with Python3;
+    # # but it should not be so problematic in this case, so keeping now just
+    # # like that to keep it simple
+    from io import StringIO
+
 from leapp.utils.i18n import _  # noqa; pylint: disable=redefined-builtin
 from leapp.snactor import commands
 from leapp.snactor.commands import workflow
@@ -73,6 +84,17 @@ def cli(args):
 
 
 def main():
+    profile_enabled = os.environ.get('LEAPP_CPROFILE', '0') == '1'
+    if profile_enabled:
+        pr = cProfile.Profile()
+        pr.enable()
     os.environ['LEAPP_HOSTNAME'] = socket.getfqdn()
     load_commands()
     cli.command.execute(version=_('snactor version {}').format(VERSION))
+    if profile_enabled:
+        pr.disable()
+        s = StringIO.StringIO()
+        sortby = 'cumulative'
+        ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
+        ps.print_stats()
+        print(s.getvalue())

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -112,6 +112,11 @@ Skip actions that use Red Hat Subscription Manager. Equivalent to \fB--no-rhsm\f
 For each XFS partition created with \fIftype=0\fR, leapp creates an overlay file in order to proceed. This option sets the size (in MB) of every such file. Defaults to \fB2048\fR.
 .RE
 
+.B LEAPP_CPROFILE
+.RS 4
+Enables profiling.
+.RE
+
 
 .SS Developer variables
 These variables shouldn't be needed under typical circumstances.

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -89,6 +89,11 @@ Enables debug logging. See \fB--debug\fR for more information.
 Enables verbose logging. See \fB--verbose\fR for more information.
 .RE
 
+.B LEAPP_CPROFILE
+.RS 4
+Enables profiling.
+.RE
+
 
 .SH "REPORTING BUGS"
 Report bugs to bugzilla (\fIhttps://bugzilla.redhat.com\fR) under the `Red Hat Enterprise Linux 7` product and the `leapp-repository` component.


### PR DESCRIPTION
Picking up where #482 left off. For science, profit and fun.

`LEAPP_CPROFILE=1` turns on the profiler and shows stats after a _successful_ execution. Maybe an option would be better instead...