### PR TITLE
[WIP] Packaging: prepare building for RHEL 8 (Python3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTHON_VENV ?= python
 VENVNAME ?= tut
+DIST_VERSION ?= 7
 CONFDIR=${DESTDIR}/etc/leapp
 LIBDIR=${DESTDIR}/var/lib/leapp
 
@@ -88,13 +89,13 @@ srpm: source
 	@rpmbuild -bs packaging/$(PKGNAME).spec \
 		--define "_sourcedir `pwd`/packaging/sources"  \
 		--define "_srcrpmdir `pwd`/packaging/SRPMS" \
-		--define "rhel 7" \
-		--define 'dist .el7' \
-		--define 'el7 1' || FAILED=1
+		--define "rhel $(DIST_VERSION)" \
+		--define 'dist .el$(DIST_VERSION)' \
+		--define 'el$(DIST_VERSION) 1' || FAILED=1
 	@mv packaging/$(PKGNAME).spec.bak packaging/$(PKGNAME).spec
 
 copr_build: srpm
-	@echo "--- Build RPM ${PKGNAME}-${VERSION}-${RELEASE}.el7.rpm in COPR ---"
+	@echo "--- Build RPM ${PKGNAME}-${VERSION}-${RELEASE}.el$(DIST_VERSION).rpm in COPR ---"
 	@echo copr --config $(_COPR_CONFIG) build $(_COPR_REPO) \
 		packaging/SRPMS/${PKGNAME}-${VERSION}-${RELEASE}*.src.rpm
 	@copr --config $(_COPR_CONFIG) build $(_COPR_REPO) \

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -20,15 +20,15 @@
 %global framework_dependencies 3
 
 # Do not build bindings for python3 for RHEL == 7
+# # Currently Py2 is dead on Fedora and we don't have to support it. As well,
+# # our current packaging is not prepared for Py2 & Py3 packages in the same
+# # time. Instead of that, make Py2 and Py3 exclusive. Possibly rename macros..
 %if 0%{?rhel} && 0%{?rhel} == 7
-%define with_python2 1
+  %define with_python2 1
+  %define without_python3 1
 %else
-%if 0%{?rhel} && 0%{?rhel} > 7
-%bcond_with python2
-%else
-%bcond_without python2
-%endif
-%bcond_without python3
+  %define without_python2 1
+  %define with_python3 1
 %endif
 
 Name:       leapp
@@ -153,7 +153,7 @@ Requires: leapp-framework-dependencies = %{framework_dependencies}
 #    https://serverfault.com/questions/411444/rpm-set-required-somepackage-0-5-0-and-somepackage-0-6-0
 # Currently, we do not use this rpm, so commenting the provides for now, until
 # we come up with reliable solution. E.g. avoid possibility to install both
-# version of frameworks - for Py2 and Py3 in the same time. Or rename the 
+# version of frameworks - for Py2 and Py3 in the same time. Or rename the
 # capability; e.g.: leapp-framework-py3
 # Provides: leapp-framework = %{framework_version}
 
@@ -234,7 +234,11 @@ rm -f %{buildroot}/%{_bindir}/leapp
 %{_bindir}/leapp
 %dir %{_sharedstatedir}/leapp
 %dir %{_localstatedir}/log/leapp
+%if %{with python2}
 %{python2_sitelib}/leapp/cli
+%else
+%{python3_sitelib}/leapp/cli
+%endif
 %endif
 
 
@@ -244,7 +248,11 @@ rm -f %{buildroot}/%{_bindir}/leapp
 ##################################################
 %files -n snactor
 %license COPYING
+%if %{with python2}
 %{python2_sitelib}/leapp/snactor
+%else
+%{python3_sitelib}/leapp/snactor
+%endif
 %{_mandir}/man1/snactor.1*
 %{_bindir}/snactor
 
@@ -271,8 +279,9 @@ rm -f %{buildroot}/%{_bindir}/leapp
 %files -n python3-%{name}
 %license COPYING
 %{python3_sitelib}/*
-#TODO: ignoring leapp and snactor in separate rpms now as we do not provide
-# entrypoints for Py3 in those subpackages anyway
+# TODO: check valid entry points for leapp & snactor
+%exclude %{python3_sitelib}/leapp/cli
+%exclude %{python3_sitelib}/leapp/snactor
 
 %endif
 

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -155,7 +155,9 @@ Requires: leapp-framework-dependencies = %{framework_dependencies}
 # we come up with reliable solution. E.g. avoid possibility to install both
 # version of frameworks - for Py2 and Py3 in the same time. Or rename the
 # capability; e.g.: leapp-framework-py3
-# Provides: leapp-framework = %{framework_version}
+# UPDATE: the current SPEC file build exclusively just for Py3 or Py2, so we
+# should not have these problems anymore.
+Provides: leapp-framework = %{framework_version}
 
 %description -n python3-%{name}
 Python 3 leapp framework libraries.


### PR DESCRIPTION
Make possible building of leapp and snactor utilities for Python3.
We plan to support Python2 only no RHEL 7. For all other systems,
build only for Python3.

This is now just untested POC for testing purposes

**Expected command for building now**:
```bash
PR=678 COPR_REPO=leapp9-poc DIST_VERSION=8 make copr_build
```