### PR TITLE
snactor.sanity-check: Add option to ignore models

### DIFF
--- a/leapp/snactor/commands/workflow/sanity_check.py
+++ b/leapp/snactor/commands/workflow/sanity_check.py
@@ -1,19 +1,23 @@
 from __future__ import print_function
+
 import sys
 
-from leapp.exceptions import LeappError, CommandError
+from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.snactor.commands.workflow import workflow
-from leapp.utils.clicmd import command_arg
+from leapp.utils.clicmd import command_arg, command_opt
 from leapp.utils.output import Color
-from leapp.utils.repository import requires_repository, find_repository_basedir
+from leapp.utils.repository import find_repository_basedir, requires_repository
 
 _DESCRIPTION = 'The following messages are attempted to be consumed before they are produced: {}'
 _LONG_DESCRIPTION = '''
 Perform workflow sanity checks
 
 - check whether there is a message in the given workflow which is attempted to be consumed before it was produced
+  --ignore <MODEL> can be used to specify one or multiple times to ignore the above condition
+  --ignorefile <PATH to ignore file> can be used to specify a file to load a list of ignored models. The list shall be
+    new line separated. Lines beginning with # are considered comments.
 
 For more information please consider reading the documentation at:
 https://red.ht/leapp-docs
@@ -24,10 +28,19 @@ def print_fail(error):
     print('{red}FAIL: {error}{reset}'.format(red=Color.red, error=error, reset=Color.reset), file=sys.stderr, end='\n')
 
 
+def _ignore_file_content(path):
+    if path:
+        with open(path) as f:
+            return [line.strip() for line in f.read().split('\n') if not line.strip().startswith('#')]
+
+
 @workflow.command('sanity-check', help='Perform workflow sanity checks', description=_LONG_DESCRIPTION)
 @command_arg('name')
+@command_opt('ignore', metavar='<MODEL>', action='append', help='Models to ignore in the sanity check.')
+@command_opt('ignorefile', metavar='<PATH to ignore file>', help='File with a list of model names to ignore.')
 @requires_repository
 def cli(params):
+    ignored_models = set(params.ignore or []) | set(_ignore_file_content(params.ignorefile))
     configure_logger()
     repository = find_and_scan_repositories(find_repository_basedir('.'), include_locals=True)
     try:
@@ -43,6 +56,7 @@ def cli(params):
 
     instance = wf()
     produced_late = set(instance.initial).intersection(set(instance.produces))
-    if produced_late:
+    produced_late_names = [model.__name__ for model in produced_late if model.__name__ not in ignored_models]
+    if produced_late_names:
         print_fail(_DESCRIPTION.format(' '.join([m.__name__ for m in produced_late])))
         sys.exit(1)

--- a/leapp/snactor/commands/workflow/sanity_check.py
+++ b/leapp/snactor/commands/workflow/sanity_check.py
@@ -29,9 +29,10 @@ def print_fail(error):
 
 
 def _ignore_file_content(path):
-    if path:
-        with open(path) as f:
-            return [line.strip() for line in f.read().split('\n') if not line.strip().startswith('#')]
+    if not path:
+        return []
+    with open(path) as f:
+        return [line.strip() for line in f.read().split('\n') if line.strip() and not line.strip().startswith('#')]
 
 
 @workflow.command('sanity-check', help='Perform workflow sanity checks', description=_LONG_DESCRIPTION)


### PR DESCRIPTION
Previously, if a Model was being consumed by actor before it was
produced,  `snactor sanity-check` reported a failure. This however
blocks some use case in leapp-repository now, where there is the
possibility to supply user data and it is being verified before in a
later stage it actually is used. This sanitization actor causes this
check to fail and would force an ugly workaround by having a dummy actor
pretending to produce the message earlier.

This patch will introduce two ways of handling this situation by
ignoring the models. Either each model can be specified as a commandline
option --ignore or a path to a file containing a list of such models can
be supplied via --ignorefile.
Any of those specified model names supplied via --ignore or the
ignore file will no longer be considered a failure.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>