### PR TITLE
Bump framework_version to 1.4

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 1.3
+%global framework_version 1.4
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage


### PR DESCRIPTION
Regarding the new functionality (reporting.Key) providing the stable
key id for every report, the framework version should be bumped to
keep stuff compatible.