### PR TITLE
Release 0.12.0

### DIFF
--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,6 +1,6 @@
 from leapp.utils.workarounds import apply_workarounds
 
-VERSION = "0.11.1"
+VERSION = "0.12.0"
 FULL_VERSION = VERSION
 
 apply_workarounds()

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,4 +1,4 @@
-.TH LEAPP "1" "2020-10-20" "leapp 0.11.1" "User Commands"
+.TH LEAPP "1" "2021-02-04" "leapp 0.12.0" "User Commands"
 
 .SH NAME
 leapp \- command line interface for upgrades between major OS versions

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,4 +1,4 @@
-.TH SNACTOR "1" "2020-10-20" "snactor 0.11.1" "User Commands"
+.TH SNACTOR "1" "2021-02-04" "snactor 0.12.0" "User Commands"
 
 .SH NAME
 snactor \- development and repository management tool for leapp

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -32,7 +32,7 @@
 %endif
 
 Name:       leapp
-Version:    0.11.1
+Version:    0.12.0
 Release:    1%{?dist}
 Summary:    OS & Application modernization framework
 


### PR DESCRIPTION
## Packaging
- Add JSON schema of leapp reports for validation (#681)
- Bump leapp-framework capability to 1.4 (#684)

## Framework
### Fixes
- Fix Py2/Py3 issues for unit-tests relying on __wrapped__ for decorators (#674)

### Enhancements
- Add a stable report identifier for each generated report (#669)


## Additional changes interesting for devels
- Add a possibility to overwrite virtualenv name for testing  `$VENVNAME` (#675)
- Add a way to override default python version using `$PYTHON_VENV` (#675)

Related leapp-repository release: https://github.com/oamg/leapp-repository/releases/tag/v0.13.0