### PR TITLE
Control leapp-report format

### DIFF
--- a/leapp/config.py
+++ b/leapp/config.py
@@ -48,7 +48,8 @@ _CONFIG_DEFAULTS = {
         'dir': '/var/log/leapp/',
         'files': ','.join(_REPORTS),
         'answerfile': '/var/log/leapp/answerfile',
-        'userchoices': '/var/log/leapp/answerfile.userchoices'
+        'userchoices': '/var/log/leapp/answerfile.userchoices',
+        'schema': '1.1.0'
     },
     'repositories': {
         'repo_path': '.',

--- a/leapp/utils/report.py
+++ b/leapp/utils/report.py
@@ -89,7 +89,9 @@ def importance(message):
     return SEVERITY_LEVELS.get(message['severity'], 99)
 
 
-def generate_report_file(messages_to_report, context, path):
+def generate_report_file(messages_to_report, context, path, report_schema='1.1.0'):
+    # NOTE(ivasilev) Int conversion should not break as only specific formats of report_schema versions are allowed
+    report_schema_tuple = tuple([int(x) for x in report_schema.split('.')])
     if path.endswith(".txt"):
         with open(path, 'w') as f:
             for message in sorted(messages_to_report, key=importance):
@@ -100,8 +102,17 @@ def generate_report_file(messages_to_report, context, path):
                 remediation = Remediation.from_dict(message.get('detail', {}))
                 if remediation:
                     f.write('Remediation: {}\n'.format(remediation))
-                f.write('Key: {}\n'.format(message['key']))
+                if report_schema_tuple > (1, 0, 0):
+                    # report-schema 1.0.0 doesn't have a stable report key
+                    f.write('Key: {}\n'.format(message['key']))
                 f.write('-' * 40 + '\n')
     elif path.endswith(".json"):
         with open(path, 'w') as f:
+            # Here all possible convertions will take place
+            if report_schema_tuple < (1, 1, 0):
+                # report-schema 1.0.0 doesn't have a stable report key
+                # copy list of messages here not to mess the initial structure for possible further invocations
+                messages_to_report = list(messages_to_report)
+                for m in messages_to_report:
+                    m.pop('key')
             json.dump({'entries': messages_to_report, 'leapp_run_id': context}, f, indent=2)

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -55,6 +55,9 @@ leapp \- command line interface for upgrades between major OS versions
     Enable an experimental actor. Can be used multiple times.
     To use this variable, \fBLEAPP_UNSUPPORTED\fR has to be set. See \fBDeveloper variables\fR for more information.
 
+\fB--report-schema\fR <\fIversion\fR>
+    Force the report format to conform to a specific version of the report schema. Expected values: \fB1.0.0\fR, \fB1.1.0\fR. Defaults to \fB1.1.0\fR.
+
 \fB--reboot\fR
     (upgrade only) Automatically perform reboot when requested.
 


### PR DESCRIPTION
In order to be completely safe that any changes that land in leapp
reporting don't break older clients there should be a possibility
to force specific version of json schema.
Currently there are 2 schemas that are actually backward compatible,
but it may not be the rule soon.

This patch adds a --report-schema option to leapp preupgrade/upgrade
commands that force sticking to specific version of the report schema.
For example with --report-schema '1.0.0' passed there will be no stable
keys in the report messages, as those have been added in the recent
'1.1.0' report schema.