### PR TITLE
Doc: add lists of the deprecated functionalites

### DIFF
--- a/docs/source/deprecation.md
+++ b/docs/source/deprecation.md
@@ -6,6 +6,15 @@ is evolving, it happens that some functionality needs to be changed, replaced
 or dropped completely. Such situations are inevitable. To reduce negative
 impact on your code, we introduce the deprecation process described below.
 
+## List of the deprecated functionality in leapp
+
+The following lists cover deprecated functionality in the leapp utility, snactor,
+the leapp standard library, etc. But don't cover deprecated functionalities
+from particular leapp repositories (e.g. the [elt7toel8](https://github.com/oamg/leapp-repository/tree/master/repos/system_upgrade/el7toel8) leapp repository). For
+such information, see [Deprecated functionality in the el7toel8 repository](el7toel8/deprecation.html#deprecated-functionality-in-the-el7toel8-repository).
+
+*Note: No new deprecation present yet.*
+
 ## What is covered by deprecation process in leapp?
 
 In short, leapp entities that are supposed to be used by other developers.

--- a/docs/source/el7toel8/deprecation.md
+++ b/docs/source/el7toel8/deprecation.md
@@ -1,0 +1,28 @@
+# Deprecated functionality in the el7toel8 repository
+
+Deprecated functionality is listed under the first version that the functionality
+is deprecated in. Note that functionality may be deprecated in later versions
+but are not listed again.
+The dates in brackets correspond to the end of the deprecation protection period,
+after which the related functionality can be removed at any time.
+
+*Note* The lists cover just the functionality provided inside the el7toel8
+repository only. For the functionality deprecated in the leapp
+framework, see [List of deprecated functionality in leapp](../deprecation.html#list-of-deprecated-functionality-in-leapp)
+
+## current upstream development
+
+*Note: No new deprecation present yet.*
+
+## v0.12.0  <span style="font-size:0.5em; font-weight:normal">(till April  2021)</span>
+- Models
+   - **GrubDevice** - Deprecated because the current implementation is not reliable. GRUB device detection is now in the shared grub library. Use the `leapp.libraries.common.grub.get_grub_device()` function instead.
+   - **UpdateGrub** - Deprecated because the current implementation is not reliable. GRUB device detection is now in the shared grub library. Use the `leapp.libraries.common.grub.get_grub_device()` function instead.
+- Shared libraries
+   - **`leapp.libraries.common.testutils.logger_mocked.warn()`** - The logging.warn method has been deprecated in Python since version  3.3. Use the warning method instead.
+
+## v0.11.0 <span style="font-size:0.5em; font-weight:normal">(till April  2021)</span>
+- Models
+   - **TMPTargetRepositoriesFacts** - Deprecated because this model was not intended for customer use.
+
+

--- a/docs/source/el7toel8/leapp-repository-el7toel8.rst
+++ b/docs/source/el7toel8/leapp-repository-el7toel8.rst
@@ -8,3 +8,4 @@ This is the official upstream documentation for the leapp repository for in-plac
     actor-rhel7-to-rhel8
     inhibit-rhel7-to-rhel8
     envars
+    deprecation


### PR DESCRIPTION
Just document the stuff that is already deprecated. Added:
- a new document for the deprecated stuff in the el7toel8
  leapp repository
- a new section about deprecated stuff in leapp itself

The main deprecation document is pretty long now and the section
for the deprecated list in leapp is not good there. However I do not
see better way how to do it right now. The doc needs to be split
for sure in future, but this is not scope of this PR.