### PR TITLE
Fix the call function from the stdlib library on Python 3.9

### DIFF
--- a/leapp/libraries/stdlib/call.py
+++ b/leapp/libraries/stdlib/call.py
@@ -70,9 +70,9 @@ def _multiplex(ep, read_fds, callback_raw, callback_linebuffered,
                     continue
                 offset += os.write(fd, data[offset:])
                 if offset == len(data):
-                    os.close(fd)
                     hupped.add(fd)
                     ep.unregister(fd)
+                    os.close(fd)
 
     # Process leftovers from line buffering
     if encoding:


### PR DESCRIPTION
In short, we close a fd before the select.epoll.unregister(fd)
is called. The function originally ignored closed fd (EBADF) however
it's changed since Python 3.9+

Close the fd after it's unregistered.
See:
  - https://bugs.python.org/issue39239
  - https://github.com/python/cpython/commit/5b23f7618d434f3000bde482233c8642a6eb2c67

Thanks @shaded-enmity for the fix.

Fixes: #682

Co-authored-by: Pavel Odvody <podvody@redhat.com>