### PR TITLE
Tests: Use centos repository for docker images

### DIFF
--- a/res/docker-tests/Dockerfile
+++ b/res/docker-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.centos.org/centos:7
 
 VOLUME /payload
 

--- a/res/docker-tests/Dockerfile.centos7
+++ b/res/docker-tests/Dockerfile.centos7
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.centos.org/centos:7
 
 VOLUME /payload
 

--- a/res/docker-tests/Dockerfile.centos8
+++ b/res/docker-tests/Dockerfile.centos8
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM registry.centos.org/centos:8
 
 VOLUME /payload
 


### PR DESCRIPTION
Due to the docker hub rate limitation we will switch to be using the
registry.centos.org registry for our tests.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>