### PR TITLE
linting: Fixing reporting related warnings/errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,6 +12,7 @@ disable=
  bad-mcs-classmethod-argument,
  fixme,
  global-statement,
+ logging-format-interpolation,
  protected-access,
  redefined-outer-name,
  super-init-not-called,

--- a/tests/scripts/test_reporting.py
+++ b/tests/scripts/test_reporting.py
@@ -172,7 +172,7 @@ def test_create_report_stable_key(monkeypatch):
     report_dialog_key_set = _create_report_object(report_entries_dialog_key_set)
     # check that all reports have key field
     for report in [report1, report2, report_with_severity, report_with_audience, report_fixed_key]:
-        assert "key" in report.report
+        assert "key" in report.report  # pylint: disable = unsupported-membership-test
     # check that reports with same title but different summary have same dynamically generated key
     assert report1.report["key"] == report2.report["key"]
     # check that entries different in severity only will have different generated keys

--- a/tests/scripts/test_utils_report.py
+++ b/tests/scripts/test_utils_report.py
@@ -1,8 +1,5 @@
-from collections import namedtuple
 import datetime
 import json
-
-import pytest
 
 import leapp.utils.report
 


### PR DESCRIPTION
    There have been some new warnings/errors during the linting process,
    that probably came with a new version of pylint etc.
    This patch addresses those.