### PR TITLE
upgrade: CLI stops logging to log file after resume

### DIFF
--- a/leapp/cli/upgrade/__init__.py
+++ b/leapp/cli/upgrade/__init__.py
@@ -218,12 +218,12 @@ def upgrade(args):
             os.environ['LEAPP_VERBOSE'] = '0'
 
         skip_phases_until = get_last_phase(context)
-        logger = configure_logger()
     else:
         e = Execution(context=context, kind='upgrade', configuration=configuration)
         e.store()
         archive_logfiles()
-        logger = configure_logger('leapp-upgrade.log')
+
+    logger = configure_logger('leapp-upgrade.log')
     os.environ['LEAPP_EXECUTION_ID'] = context
 
     if args.resume:


### PR DESCRIPTION
Previously when the upgrade was resumed, leapp did not continue to write
to the leapp-upgrade.log.
This patch fixes the issue.

Bug description:

`configure_logger()` was called after resume without a parameter. Which
caused the log_file parameter of configure_logger to be None. If log_file
is None, the `FileHandler` instance wasn't created and in consequence
not added the internal logger. Which then of course never writes to the
leapp-upgrade.log

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>