### PR TITLE
testing: Adding second place for centos registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ install:
 	umask 177 && $(PYTHON_VENV) -c "import sqlite3; sqlite3.connect('${LIBDIR}/audit.db').executescript(open('res/audit-layout.sql', 'r').read())"
 
 install-container-test:
-	docker pull ${CONTAINER}
+	docker pull registry.centos.org/${CONTAINER}
 	docker build -t leapp-tests -f res/docker-tests/Dockerfile.$(subst :,,${CONTAINER}) res/docker-tests
 
 install-test:


### PR DESCRIPTION
During the previous fix, I overlooked the git pull of the container in
the Makefile. This caused a failure at that point. This PR adds the
second location where this is happening.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>