### PR TITLE
Document leapp data file service envars

### DIFF
--- a/docs/source/el7toel8/envars.md
+++ b/docs/source/el7toel8/envars.md
@@ -67,6 +67,16 @@ Necessary to use in case you use any envar with the LEAPP_DEVEL prefix
 for the Leapp tool.
 
 
+## LEAPP_SERVICE_HOST
+
+Overrides the host of the service to which leapp connects to fetch necessary data files in case they are missing. The used protocol (`http://` or `https://`) must be specified. Defaults to `https://cert.cloud.redhat.com`.
+
+
+## LEAPP_PROXY_HOST
+
+If set, leapp will use this proxy to fetch necessary data files in case they are missing. The used protocol (`http://` or `https://`) must be specified.
+
+
 ## LEAPP_DEVEL_RPMS_ALL_SIGNED
 
 Leapp will consider all installed pkgs to be signed by RH - that affects

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -112,6 +112,16 @@ Skip actions that use Red Hat Subscription Manager. Equivalent to \fB--no-rhsm\f
 For each XFS partition created with \fIftype=0\fR, leapp creates an overlay file in order to proceed. This option sets the size (in MB) of every such file. Defaults to \fB2048\fR.
 .RE
 
+.B LEAPP_SERVICE_HOST
+.RS 4
+Overrides the host of the service to which leapp connects to fetch necessary data files in case they are missing. The used protocol (\fIhttp://\fR or \fIhttps://\fR) must be specified. Defaults to \fBhttps://cert.cloud.redhat.com\fR.
+.RE
+
+.B LEAPP_PROXY_HOST
+.RS 4
+If set, leapp will use this proxy to fetch necessary data files in case they are missing. The used protocol (\fIhttp://\fR or \fIhttps://\fR) must be specified.
+.RE
+
 
 .SS Developer variables
 These variables shouldn't be needed under typical circumstances.


### PR DESCRIPTION
Documents two new environment variables introduced in oamg/leapp-repository#654 in upstream docs and the manual page.