### PR TITLE
Set the default shell used in Makefile to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# there are bashisms used in this Makefile
+SHELL=/bin/bash
+
 PYTHON_VENV ?= python
 VENVNAME ?= tut
 CONFDIR=${DESTDIR}/etc/leapp


### PR DESCRIPTION
The default shell in Makefile is `sh` and since bashisms are used in the
Makefile, some of the targets fail, depending on setting of the system
(not an issue on vanilla Fedora where `/bin/sh` is a symlink to `bash`).