### PR TITLE
DOC: update current devel deprecation regarding initramfs stuff

### DIFF
--- a/docs/source/el7toel8/deprecation.md
+++ b/docs/source/el7toel8/deprecation.md
@@ -10,9 +10,13 @@ after which the related functionality can be removed at any time.
 repository only. For the functionality deprecated in the leapp
 framework, see [List of deprecated functionality in leapp](../deprecation.html#list-of-deprecated-functionality-in-leapp)
 
-## current upstream development
+## current upstream development <span style="font-size:0.5em; font-weight:normal">(till the next release + 6months)</span>
 
-*Note: No new deprecation present yet.*
+- Models
+  - **RequiredTargetUserspacePackages** - Deprecated because the new solution has been designed. Use the `TargetUserspacePreupgradeTasks` instead (see the `install_rpms` field).
+  - **RequiredUpgradeInitramPackages** - Deprecated because the new solution around the upgrade initramfs has been designed. Use the `TargetUserspaceUpgradeTasks` instead (see the `install_rpms` field).
+  - **UpgradeDracutModule** - Replaced by `UpgradeInitramfsTasks` (see the `include_dracut_modules` field).
+  - **InitrdIncludes** - Deprecated becase the new solution around the target initramfs (read: initramfs created for the upgraded system) has been designed. Use the `TargetInitramfsTasks` instead (see the `include_files` field).
 
 ## v0.12.0  <span style="font-size:0.5em; font-weight:normal">(till April  2021)</span>
 - Models


### PR DESCRIPTION
The new solution around the target userspace container, the upgrade
initramfs, and the target initramfs has been merged in leapp-repository
upstream for el7toel8. With that, 4 models has become deprecated as
these have been replaced by new models.

Deprecated models:
  - RequiredTargetUserspacePackages
  - RequiredUpgradeInitramPackages
  - UpgradeDracutModule
  - InitrdIncludes