### PR TITLE
Fix the pip installation in Dockerfile for unit-tests

### DIFF
--- a/res/docker-tests/Dockerfile
+++ b/res/docker-tests/Dockerfile
@@ -3,7 +3,11 @@ FROM registry.centos.org/centos:7
 VOLUME /payload
 
 RUN yum update -y && \
-    yum install python-virtualenv make -y
+    yum install python-virtualenv make -y && \
+    yum -y install epel-release && \
+    yum -y install python-pip python3-pip && \
+    python2 -m pip install --upgrade pip==20.3.4 && \
+    python3 -m pip install --upgrade pip==20.3.4
 
 WORKDIR /payload
 ENTRYPOINT virtualenv testenv && \

--- a/res/docker-tests/Dockerfile.centos7
+++ b/res/docker-tests/Dockerfile.centos7
@@ -3,7 +3,11 @@ FROM registry.centos.org/centos:7
 VOLUME /payload
 
 RUN yum update -y && \
-    yum install python-virtualenv make -y
+    yum install python-virtualenv make -y && \
+    yum -y install epel-release && \
+    yum -y install python-pip python3-pip && \
+    python2 -m pip install --upgrade pip==20.3.4 && \
+    python3 -m pip install --upgrade pip==20.3.4
 
 WORKDIR /payload
 ENTRYPOINT virtualenv testenv && \

--- a/res/docker-tests/Dockerfile.centos8
+++ b/res/docker-tests/Dockerfile.centos8
@@ -3,7 +3,10 @@ FROM registry.centos.org/centos:8
 VOLUME /payload
 
 RUN yum update -y && \
-    yum install python3-virtualenv make -y
+    yum install python3-virtualenv make -y && \
+    yum -y install epel-release && \
+    yum -y install python3-pip && \
+    python3 -m pip install --upgrade pip==20.3.4
 
 WORKDIR /payload
 ENTRYPOINT virtualenv testenv && \


### PR DESCRIPTION
The easy_install script is not usable anymore since the html page
changed the format and the script is not able to discover required
python packages anymore. Instead of that, install pip from centos
(includes installation of the EPEL repository), update it to version
we require and continue..

As well, to omit possible additional problems in future with pip for
Python3, let's install in the container python3-pip and update it
to the very same version (v20.3.4) too.

Co-Author: Petr Stodulka <pstodulk@redhat.com>
Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>