### PR TITLE
Pass copr build properly

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -95,7 +95,7 @@ jobs:
             "environments": [{
               "arch": "x86_64",
               "os": {"compose": "RHEL-7.9-updates-20201124.0"},
-              "artifacts": [{"type": "fedora-copr-build", "id": "${{ steps.copr_build.outputs.copr_id }}"}],
+              "artifacts": [{"type": "fedora-copr-build", "id": "${{ steps.copr_build.outputs.copr_id }}:epel-7-x86_64"}],
               "variables": {
                 "REPO": "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY",
                 "REF": "${{ steps.ref_sha.outputs.ref }}",


### PR DESCRIPTION
Artifacts to be installed should come in build_id:chroot_name form.

Ex. "artifacts": [{"type": "fedora-copr-build", "id": "2220887:epel-7-x86_64"}]