### PR TITLE
Packaging: prepare building for RHEL 8+  and Fedora (iow, for Python3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL=/bin/bash
 
 PYTHON_VENV ?= python
 VENVNAME ?= tut
+DIST_VERSION ?= 7
 CONFDIR=${DESTDIR}/etc/leapp
 LIBDIR=${DESTDIR}/var/lib/leapp
 
@@ -91,13 +92,13 @@ srpm: source
 	@rpmbuild -bs packaging/$(PKGNAME).spec \
 		--define "_sourcedir `pwd`/packaging/sources"  \
 		--define "_srcrpmdir `pwd`/packaging/SRPMS" \
-		--define "rhel 7" \
-		--define 'dist .el7' \
-		--define 'el7 1' || FAILED=1
+		--define "rhel $(DIST_VERSION)" \
+		--define 'dist .el$(DIST_VERSION)' \
+		--define 'el$(DIST_VERSION) 1' || FAILED=1
 	@mv packaging/$(PKGNAME).spec.bak packaging/$(PKGNAME).spec
 
 copr_build: srpm
-	@echo "--- Build RPM ${PKGNAME}-${VERSION}-${RELEASE}.el7.rpm in COPR ---"
+	@echo "--- Build RPM ${PKGNAME}-${VERSION}-${RELEASE}.el$(DIST_VERSION).rpm in COPR ---"
 	@echo copr-cli --config $(_COPR_CONFIG) build $(_COPR_REPO) \
 		packaging/SRPMS/${PKGNAME}-${VERSION}-${RELEASE}*.src.rpm
 	@copr-cli --config $(_COPR_CONFIG) build $(_COPR_REPO) \


### PR DESCRIPTION
The SPEC file has been simplified to make the maintaining simple for
people. As the set of changes seems biger regarding that, here
is the list of changes explicitly:

* The building for Python2 and Python3 is now exclusive.
  Python2 is supported only on RHEL 7. For all newer systems
  (Fedora including) build just with Python3.

* Additionaly the python3-leapp packages provides leapp-framework
  as expected.

* Remove auto generated python(abi) dependency on Python3 systems
  Various versions of systems (RHEL 8, RHEL 9, Fedora 33, Fedora 34)
  use different versions of Python. This means the python(abi) is
  different on each system, however leapp packages (excluding the
  deps metapackage) has to survive the upgrade of the system
  untouched. This is not possible when requirements on python(abi)
  is defined, so drop this dependency from all packages.
  * python(abi) for Python2 is kept untouched for historical reasons
    and because python 2.7 is on both - RHEL 7 and RHEL 8 systems.

* Remove autogenerated /usr/libexec/platform-python dependency on EL8
  It's analogy to the problem above. Just in this case, this dependency
  has been generated just on EL 8 systems. However the platform-python
  will not exist anymore on newer systems.

* Additionally disable auto generation of Python3 dependencies.
  The dependencies are expected to be handled via the deps package,
  however the autogenerated deps were put into the python3-leapp rpm,
  which is not what we want (it breaks our handy solution with deps
  in case of IPU).

* Set the conflifcts between python2-leapp and python3-leapp pkgs
  We build only for Python2 of Python3, so enable installation only
  one of those two packages. As well we do not want to set provides
  and bosoletes for Python2, because packages from one system cannot
  be just updated by packages from another system.

* Enable building of leapp on Fedora
  Since the leapp tool doesn't provide any specific commits, it's
  no problem to enable it's building for the Fedora - as it doesn't
  depends on leapp-repository neither. The manpage is still confusing
  but that's going to be updated in the separate PR.


---
## old notes
* **Comment out the python abi requirement.**
  * We need to discuss this one later.
currently, with the generated python(abi) = 3.6 it's not possible to preserve
the rpm on RHEL 9 system. let's talk about consequences of the removal later
    * **UPDATE**: I have discussed that already and think it should be ok for us. However I need to find out any comment from the past where I put the result of the discussion with the python team. The problem is that python-abi on RHEL 8 is 3.6, but on RHEL 9 it's newer, which breaks the upgrade path with the leapp.

* **Comment out auto generation of Python3 dependencies**
  * The dependencies are expected to be handled via the deps package,
however the autogenerated deps are put into the python3-leapp rpm,
which is not what we want (it breaks our handy solution with deps
in case of IPU.
