### PR TITLE
models: Do not make references for private symbols

### DIFF
--- a/leapp/models/__init__.py
+++ b/leapp/models/__init__.py
@@ -25,13 +25,12 @@ Now, the models can be used like this::
 """
 import sys
 
+from leapp.exceptions import ModelDefinitionError
 from leapp.models import fields
 from leapp.models.error_severity import ErrorSeverity
-
-from leapp.exceptions import ModelDefinitionError
 from leapp.models.fields import ModelMisuseError
+from leapp.topics import DialogTopic, ErrorTopic, Topic
 from leapp.utils.meta import get_flattened_subclasses, with_metaclass
-from leapp.topics import ErrorTopic, DialogTopic, Topic
 
 
 class ModelMeta(type):
@@ -219,6 +218,10 @@ def _patch_module_getitem():
             delattr(self._module, name)
 
         def __getattr__(self, item):
+            # Redirect private imports to the module and don't use our magic
+            # We do not support importing private Module symbols
+            if item.startswith('_'):
+                return getattr(self._module, item)
             return getattr(self._module, item, None) or _module_ref(item)
 
     sys.modules[__name__] = ReferenceDict(sys.modules[__name__])


### PR DESCRIPTION
Previously there was a reference for Models created for every symbol
attempted to being imported from leapp.models, however pytest tries to
import `_pytestfixturefunction` which is not a model obviously.
To work around pytest causing failures because of that, private symbols
are being filtered from the model reference creation magic.


For reference, this is what you would see running pytest without this fix:
```
....
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/usr/local/lib/python3.9/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/vfeenstr/leapp-repository/conftest.py", line 45, in pytest_collectstart
INTERNALERROR>     _load_and_add_repo(collector.session.leapp_repository, current_repo_basedir)
INTERNALERROR>   File "/home/vfeenstr/leapp-repository/conftest.py", line 31, in _load_and_add_repo
INTERNALERROR>     manager.repo_by_id(repo_id).load(skip_actors_discovery=True)
INTERNALERROR>   File "/home/vfeenstr/.local/lib/python3.9/site-packages/leapp/repository/__init__.py", line 135, in load
INTERNALERROR>     resolve_model_references()
INTERNALERROR>   File "/home/vfeenstr/.local/lib/python3.9/site-packages/leapp/models/__init__.py", line 201, in resolve_model_references
INTERNALERROR>     reference.resolve()
INTERNALERROR>   File "/home/vfeenstr/.local/lib/python3.9/site-packages/leapp/models/__init__.py", line 188, in resolve
INTERNALERROR>     raise ModelDefinitionError('Undefined Model "{}"'.format(cls._referenced))
INTERNALERROR> leapp.exceptions.ModelDefinitionError: Undefined Model "_pytestfixturefunction"
```