### PR TITLE
Add the _lookup_actors function into the repo manager

### DIFF
--- a/leapp/repository/__init__.py
+++ b/leapp/repository/__init__.py
@@ -63,6 +63,7 @@ class Repository(object):
         :type name: str
         :return: None or Actor
         """
+        # TODO: what's the behaviour in case of multiple actors of the same name?
         name = name.lower()
         for actor in self.actors:
             actor_name = actor.name.lower()

--- a/leapp/repository/manager.py
+++ b/leapp/repository/manager.py
@@ -26,6 +26,26 @@ class RepositoryManager(object):
                 return actor
         return None
 
+    def _lookup_actors(self, name):
+        """
+        Find all actors of the given name in all loaded repositories.
+
+        Returns list of all actors of the given name in the loaded repositories
+        or empty list.
+
+        :param name: Name of the actor
+        :type name: str
+        :return: list
+        """
+        # FIXME: returns max 1 actor per repository (bug in the lookup_actor)
+        actors = []
+        for repo in self._repos.values():
+            actor = repo.lookup_actor(name)
+            if actor:
+                actors.append(actor)
+        return actors
+
+
     def lookup_workflow(self, name):
         """
         Find workflow in all loaded repositories


### PR DESCRIPTION
The RepositoryManager.lookup_actor function returns always just one
Actor or None. However, in case the actor of the same name is specified
in multiple repositories I would like to have an info about all these
actors. Currently I am not sure whether there is a mechanism to prevent
people having actors with identical name in multiple repositories when
leapp is running, but so far, tests do not react on the situation when
some actors of the same name exists. For now, creating this private
function to be able to run unit tests for actors of specific name
in all available repos.

@vinzenz @Rezney  somthing for the discussion guys. I choosed this way (the private method) for now as we will not introduce functionality anyone should be care of so easy to remove whenever we want in the future and do not have to discuss this so much for now I believe.