### PR TITLE
Drop dependency on /usr/bin/python3.6

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -38,7 +38,7 @@
   %define leapp_py_install %{py3_install}
   # we have to drop the dependency on python(abi) completely on el8+ because
   # of IPU (python abi is different between systems)
-  %global __requires_exclude ^python\\(abi\\) = 3\\..+|/usr/libexec/platform-python
+  %global __requires_exclude ^python\\(abi\\) = 3\\..+|/usr/libexec/platform-python|/usr/bin/python.*
 %endif
 
 Name:       leapp


### PR DESCRIPTION
There is difference in the automaticly generated dependencies when the RPM is built in the internal COPR for RHEL-8 or when it's built in public COPR for EPEL-8:
 - EPEL-8: `/usr/bin/python3.6`
 - RHEL-8: `/usr/libexec/platform-python`

Extending the `__requires_exclude` macro to drop both.

In case the dependency is not dropped, the `leapp` rpm is automatically removed during the upgrade process which ends with the emergency mode as we are not able to run leapp after the rpm transaction is processed.