### PR TITLE
Fix leapp prints nothing when running with no args on python3.6+

### DIFF
--- a/leapp/utils/clicmd.py
+++ b/leapp/utils/clicmd.py
@@ -87,7 +87,8 @@ class Command(object):
         parser.add_argument('--version', action='version', version=version)
         parser.set_defaults(func=None)
         if self._sub_commands:
-            s = parser.add_subparsers(title='Main commands', metavar='')
+            s = parser.add_subparsers(title='Required arguments', metavar='command')
+            s.required = True
         else:
             s = parser
         self.apply_parser(s, parser=parser)


### PR DESCRIPTION
A change introduced in the stdlib argparse module accidentally caused
all subparsers to become optional instead of required as in python 2.7.
This change therefore causes leapp to print nothing and exit with error
code 0 when being executed without any arguments.

This commit marks the subparser action as required, so that the
python3.6 module recognizes this situation and prints the usage message.

To provide a meaningful message on python3.6 the subparser action was
edited to use 'command' metavar and the 'title' option was dropped.

Tasks to be done:
- [x] verify that the usage message when using python2.7 did not become somehow unreadable due to the `metavar`/`title` changes performed. 