### PR TITLE
devel: Speed up leapp database writes by disabling synchronization

### DIFF
--- a/leapp/utils/audit/__init__.py
+++ b/leapp/utils/audit/__init__.py
@@ -37,6 +37,15 @@ def _initialize_database(db):
         else:
             for migration in MIGRATIONS[index:]:
                 db.executescript(migration[1])
+
+    if os.environ.get('LEAPP_DEVEL_DATABASE_SYNC_OFF'):
+        db.execute('PRAGMA journal_mode = WAL')
+        # This code speeds up leapp by a factor of almost 18 in some scenarios
+        # however comes at the cost of potential database corruption
+        # According to the SQLITE documentation this corruption can only happen
+        # in case of power loss or an OS crash.
+        db.execute('PRAGMA synchronous = 0')
+
     return db
 
 


### PR DESCRIPTION
This patch introduces an optimization of the database access when the
LEAPP_DEVEL_DATABASE_SYNC_OFF environment variable is set.

This causes to write to the database up to 20 times faster than normal,
depending on the underlying hard drive and file system.

I managed to increase the speed leapp preupgrade from 9 minutes 7
seconds to 26 seconds.

However this feature comes at the cost of risking database corruption,
in case of powerloss or OS crashes. According to the SQLite
documentation, application crashes are safe.

Since this option poses a potential risk, it is deemed for now
a development option only and will help to speed up our CI systems.