### PR TITLE
Python 3.9 compatibility

### DIFF
--- a/leapp/utils/workarounds/mp.py
+++ b/leapp/utils/workarounds/mp.py
@@ -1,8 +1,18 @@
 import os
 import multiprocessing.util
+import multiprocessing
+
+_start_method_set = False
 
 
 def apply_workaround():
+    global _start_method_set
+    # Set start method for multiprocessing to fork (3.4+)
+    set_start_method = getattr(multiprocessing, 'set_start_method', None)
+    if not _start_method_set and set_start_method:
+        set_start_method('fork')
+        _start_method_set = True
+
     # Implements:
     # https://github.com/python/cpython/commit/e8a57b98ec8f2b161d4ad68ecc1433c9e3caad57
     #

--- a/tests/scripts/test_actor_api.py
+++ b/tests/scripts/test_actor_api.py
@@ -13,7 +13,7 @@ from leapp.models import ApiTestConsume, ApiTestProduce
 from leapp.repository.scan import scan_repo
 
 
-logging.basicConfig(format='%(asctime)-15s %(clientip)s %(user)-8s %(message)s')
+logging.basicConfig(format='%(asctime)-15s %(message)s')
 
 
 class _TestableMessaging(BaseMessaging):


### PR DESCRIPTION
In Python 3.9 tests fail on macos because multiprocessing does no longer fork, to prevent this behavior from changing at all this PR adds a workaround for this.

Related issue #690