### PR TITLE
Release 0.13.0

### DIFF
--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,6 +1,6 @@
 from leapp.utils.workarounds import apply_workarounds
 
-VERSION = "0.12.1"
+VERSION = "0.13.0"
 FULL_VERSION = VERSION
 
 apply_workarounds()

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,4 +1,4 @@
-.TH LEAPP "1" "2021-02-04" "leapp 0.12.1" "User Commands"
+.TH LEAPP "1" "2021-10-19" "leapp 0.13.0" "User Commands"
 
 .SH NAME
 leapp \- command line interface for upgrades between major OS versions

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,4 +1,4 @@
-.TH SNACTOR "1" "2021-02-04" "snactor 0.12.1" "User Commands"
+.TH SNACTOR "1" "2021-10-19" "snactor 0.13.0" "User Commands"
 
 .SH NAME
 snactor \- development and repository management tool for leapp

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -42,7 +42,7 @@
 %endif
 
 Name:       leapp
-Version:    0.12.1
+Version:    0.13.0
 Release:    1%{?dist}
 Summary:    OS & Application modernization framework
 


### PR DESCRIPTION
## Packaging
- Drop the dependency on leapp-repository for Fedora and RHEL 8+ (#717)
- Provide builds for RHEL 7+ and Fedora (#717)
- Drop automatically generated Python dependences on RHEL 8+ and Fedora systems (#717, #716)
- Bump the provided leapp-framework capability to 2.0 (#700)

## Framework
### Fixes
- models: Do not make references to private symbols (#718)

### Enhancements
- Introduce the LEAPP_DEVEL_DATABASE_SYNC_OFF envar to enable speed up writes into the leapp database by disabling synchronisation - only for development / testing purposes (#732)

## Leapp
### Fixes
- Fix print of the leapp help msg for Python 3.6+ (#731)

### Enhancements
- The leapp commands are now defined/provided by leapp-repositories; leapp discovers the specified commands automatically (#700)
- Add CLI support for `choices` and `default` for options of leapp commands (#734)

## Modifications
- Makefile: Added the `fast_lint` target to apply linters just on files different from master (#733)