### PR TITLE
Change tmt plans filtering

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -91,7 +91,7 @@ jobs:
             "test": {"fmf": {
               "url": "https://gitlab.cee.redhat.com/oamg/tmt-plans",
               "ref": "master",
-              "name": "morf-leapp|integration|e2e"
+              "name": "^(?!.*c2r)(?!.*sap)"
             }},
             "environments": [{
               "arch": "x86_64",


### PR DESCRIPTION
Instead of specifying which tests to run (leapp, integration, e2e)
switch to specifying which tests to skip (c2r, sap).