### PR TITLE
Add default upgrade_paths generation

### DIFF
--- a/etc/leapp/leapp.conf
+++ b/etc/leapp/leapp.conf
@@ -4,3 +4,5 @@ repo_path=/etc/leapp/repos.d/
 [database]
 path=/var/lib/leapp/leapp.db
 
+[upgrade]
+upgrade_paths=/usr/share/leapp-repository/upgrade_paths.json

--- a/leapp/config.py
+++ b/leapp/config.py
@@ -53,6 +53,9 @@ _CONFIG_DEFAULTS = {
     'repositories': {
         'repo_path': '.',
     },
+    'upgrade': {
+        'upgrade_paths': '/usr/share/leapp-repository/upgrade_paths.json',
+    },
 }
 
 


### PR DESCRIPTION
For POC leapp.conf will store basic information about possible
upgrade_paths. Maybe will move to some other place later.