### PR TITLE
Bump leapp-framework to 2.1

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 2.0
+%global framework_version 2.1
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage


### PR DESCRIPTION
Regarding the recent changes, we provide new functionality regarding
get_*_path() functions - so the shared/common paths that do not
require execution of actors, can be used. This is useful e.g. when
we want to get specific files for the purpose of commands. Previous
use in actors is not affected by this change, however, use of these
functions outside of actors (e.g. in leapp commands) requires the
new implementation strictly.

Fixes: #742
Relates: https://github.com/oamg/leapp-repository/pull/753