### PR TITLE
Add python(abi) == 3.x deps for RHEL 8+ into the meta-pkg

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -17,7 +17,7 @@
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage
-%global framework_dependencies 3
+%global framework_dependencies 4
 
 # Do not build bindings for python3 for RHEL == 7
 # # Currently Py2 is dead on Fedora and we don't have to support it. As well,
@@ -38,6 +38,9 @@
   %define leapp_py_install %{py3_install}
   # we have to drop the dependency on python(abi) completely on el8+ because
   # of IPU (python abi is different between systems)
+  # NOTE: however, we will set the abi deps inside the meta-package, as RHEL 8
+  # could contain various python 3 versions and we can handle just one version
+  # per package.
   %global __requires_exclude ^python\\(abi\\) = 3\\..+|/usr/libexec/platform-python|/usr/bin/python.*
 %endif
 
@@ -137,6 +140,13 @@ Requires: python-requests
 Requires: python3-six
 Requires: python3-setuptools
 Requires: python3-requests
+%if 0%{?rhel} == 8
+# this prevents situation when someone would like to install leapp with
+# python-3.8+ on RHEL 8, but does not affect any else systems nor upgrades.
+Requires: python(abi) = 3.6
+%else # rhel 9
+Requires: python(abi) = 3.9
+%endif
 %endif
 Requires: findutils
 ##################################################


### PR DESCRIPTION
On RHEL 8 it could happen that people replace the original Python 3.6
by Python 3.8+. However, regarding the build & installation process,
we can support just ONE version of python per RPM - except the newer
version of python on the upgraded system, which is handled during
the upgrade by our workarounds. For that reason we put the abi
dependency back into the metapackage for RHEL 8 system only.

Example of the problem on RHEL 8:
```
# leapp
-bash: /usr/bin/leapp: /usr/bin/python3.6: bad interpreter: No such file or directory
```