### PR TITLE
Packaging: Added note into the spec about noarch

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -49,6 +49,8 @@ Summary:    OS & Application modernization framework
 License:    ASL 2.0
 URL:        https://oamg.github.io/leapp/
 Source0:    https://github.com/oamg/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+
+# NOTE: Our packages must be noarch. Do no drop this in any way.
 BuildArch:  noarch
 
 Requires: %{leapp_python_name}-%{name} = %{version}-%{release}


### PR DESCRIPTION
Our packages have to stay noarch in future for various reasons.
To reduce stress of some people, let's make it more explicit that
if someone see the change from noarch to arch specific packages,
the change must not be merged.