### PR TITLE
Fix store of answers on Python3.6 (DictProxy)

### DIFF
--- a/leapp/messaging/answerstore.py
+++ b/leapp/messaging/answerstore.py
@@ -118,7 +118,12 @@ class AnswerStore(object):
         :return:
         """
         answer = self._storage.get(scope, fallback)
-        create_audit_entry('dialog-answer', {'scope': scope, 'fallback': fallback, 'answer': answer})
+        try:
+            create_audit_entry('dialog-answer', {'scope': scope, 'fallback': fallback, 'answer': answer})
+        except TypeError:
+            # On Python3, the answer is "sometimes" DictProxy which is not JSON serialisable.
+            # Creating the shallow copy in such a case should be ok. This is happ
+            create_audit_entry('dialog-answer', {'scope': scope, 'fallback': fallback, 'answer': answer.copy()})
         return answer
 
     def translate_for_workflow(self, workflow):


### PR DESCRIPTION
On Python3 the loaded answer is "sometimes" represented by DictProxy
object. In such a case the answer cannot be serialized into the
JSON object and storing into the audit db fails with crash.

"sometimes" ==> I have a suspicion the result is different in case
                the answer is loaded from the answerfile and
                userchoices file.

See: https://github.com/oamg/leapp-repository/pull/821

Note: This is not a proper fix. I am sending the commit from a train
      with unstable network.