### PR TITLE
Fix TypeError during JSON serialization in dialogs

### DIFF
--- a/leapp/dialogs/dialog.py
+++ b/leapp/dialogs/dialog.py
@@ -98,7 +98,7 @@ class Dialog(object):
         :return: Dictionary with answers once retrieved
         """
         store.translate(self)
-        return dict(store.get(self.scope, {}))
+        return store.get(self.scope, {})
 
     def request_answers(self, store, renderer):
         """
@@ -114,4 +114,4 @@ class Dialog(object):
             self._store = store
             renderer.render(self)
             self._store = None
-        return dict(store.get(self.scope, {}))
+        return store.get(self.scope, {})

--- a/leapp/messaging/answerstore.py
+++ b/leapp/messaging/answerstore.py
@@ -115,9 +115,11 @@ class AnswerStore(object):
 
         :param scope: Scope of the data to retrieve.
         :param fallback: Fallback value to return if not found.
-        :return:
+        :return: A shallow copy of data stored in _storage by scope key
         """
-        answer = self._storage.get(scope, fallback)
+        # NOTE(ivasilev) self.storage.get() will return a DictProxy. To avoid TypeError during later
+        # JSON serialization a copy() should be invoked to get a shallow copy of data
+        answer = self._storage.get(scope, fallback).copy()
         create_audit_entry('dialog-answer', {'scope': scope, 'fallback': fallback, 'answer': answer})
         return answer
 

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 2.1
+%global framework_version 2.2
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage


### PR DESCRIPTION
Previously a DictProxy entry was passed as part of
{dialog_section: entry} data to save in store which
failed during serialization.