### PR TITLE
Dialogs: print the reason for question in the answerfile

### DIFF
--- a/leapp/messaging/answerstore.py
+++ b/leapp/messaging/answerstore.py
@@ -201,6 +201,7 @@ class AnswerStore(object):
                         '# {}\n'.format(' {}.{} '.format(dialog.scope, component.key).center(77, '=')),
                         _comment_out('Label', component.label),
                         _comment_out('Description', component.description),
+                        _comment_out('Reason', component.reason),
                         _comment_out('Type', component.value_type.__name__),
                         _comment_out('Default', default),
                         choices,


### PR DESCRIPTION
Currently we have 2 reason fields in dialogs
  - one 'generic', for the dialog itself
  - one specific just for the particular user question

The framework now prints only the first one, which in some cases
hides important text connected to the particular question. Printing
both reasons now.