### PR TITLE
logging: Fix missing logging

### DIFF
--- a/leapp/logger/__init__.py
+++ b/leapp/logger/__init__.py
@@ -59,7 +59,7 @@ def configure_logger(log_file=None):
         path = os.getenv('LEAPP_LOGGER_CONFIG', '/etc/leapp/logger.conf')
 
         if path and os.path.isfile(path):
-            logging.config.fileConfig(path)
+            logging.config.fileConfig(path, disable_existing_loggers=False)
         else:  # Fall back logging configuration
             logging.Formatter.converter = time.gmtime
             logging.basicConfig(


### PR DESCRIPTION
Previously we started using logging before it had been initialized.
Which resulted in leapp stopping to log for some logger names the debug
output. We did not know why this happened. It turns out that fileConfig
from the logging library has a parameter disable_existing_loggers which
is by default set to True and will set all loggers that have existed
before the call to fileConfig to disabled. Which in turn will make them
stop logging of course.
This patch will change this behaviour and set disable_existing_loggers
to False in order to have existing loggers be still enabled.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>