### PR TITLE
packit: build SRPM in Copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,8 @@ specfile_path: packaging/leapp.spec
 upstream_project_url: https://github.com/oamg/leapp
 merge_pr_in_ci: false
 
+srpm_build_deps: []
+
 jobs:
 - job: copr_build
   trigger: pull_request


### PR DESCRIPTION
and be able to specify the precise list of deps needed to create the
SRPM: there are no extra for leapp, so the list is empty

Details: https://packit.dev/posts/copr-srpms/