### PR TITLE
Release 0.14.0

### DIFF
--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,6 +1,6 @@
 from leapp.utils.workarounds import apply_workarounds
 
-VERSION = "0.13.0"
+VERSION = "0.14.0"
 FULL_VERSION = VERSION
 
 apply_workarounds()

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,4 +1,4 @@
-.TH LEAPP "1" "2021-10-19" "leapp 0.13.0" "User Commands"
+.TH LEAPP "1" "2022-03-17" "leapp 0.14.0" "User Commands"
 
 .SH NAME
 leapp \- command line interface for upgrades between major OS versions

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,4 +1,4 @@
-.TH SNACTOR "1" "2021-10-19" "snactor 0.13.0" "User Commands"
+.TH SNACTOR "1" "2022-03-17" "snactor 0.14.0" "User Commands"
 
 .SH NAME
 snactor \- development and repository management tool for leapp

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -42,7 +42,7 @@
 %endif
 
 Name:       leapp
-Version:    0.13.0
+Version:    0.14.0
 Release:    1%{?dist}
 Summary:    OS & Application modernization framework
 


### PR DESCRIPTION
# Release 0.14.0

## Packaging

- Add depency on `python3` for el8+ (`python3` refers to the distribution python)
- Bump `leapp-framework` to 2.2
- Bump `leapp-framework-dependencies` to 6
- Doc: --report-schema in manpage (#686)

## Framework
### Fixes

- Fix issues with initialisation of loggers (#764)
- Fix TypeError during JSON serialization in dialogs on Python3 (#760)
- Prevent breaking the answerfile when dialog fields contain newlines (#757)
- Check answerfile upon loading (#760)
- Fix the multiprocessing on Python 3.9 on Mac OS

### Enhancements

- Dialogs: print the reason field for question in the answerfile (#762)
- Added possibility to specify the report format version (#686)

## stdlib

### Enhancements
- Introduced `stdlib.path` library `get_common_*_path` functions for the scanning repositories, actors, etc. paths outside of the actor execution (#742)