### PR TITLE
Enable building leapp for specific chroots only

### DIFF
--- a/.github/workflows/copr-build.yml
+++ b/.github/workflows/copr-build.yml
@@ -21,6 +21,7 @@ jobs:
         id: trigger_fedora_build
         env:
           COPR_CONFIG: "copr_fedora.conf"
+          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
         run: |
           cat << EOF > $COPR_CONFIG
           [copr-cli]
@@ -31,5 +32,4 @@ jobs:
           EOF
 
           pip install copr-cli
-          make copr_build
-
+          COPR_CHROOT=$COPR_CHROOT COPR_CONFIG=$COPR_CONFIG make copr_build

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -45,8 +45,13 @@ jobs:
       - name: Get latest leapp-repository master copr build id
         id: get_latest_lpr_copr_build_id
         if: ${{ steps.leapp_repository_pr_regex_match.outputs.match == '' }}
+        env:
+          COPR_CONFIG: "copr_fedora.conf"
+          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
+          COPR_REPO: "@oamg/leapp"
+          REGEX: "leapp-repository.*master.*"
         run: |
-          cat << EOF > copr_fedora.conf
+          cat << EOF > $COPR_CONFIG
           [copr-cli]
           login = ${{ secrets.FEDORA_COPR_LOGIN }}
           username = @oamg
@@ -56,14 +61,17 @@ jobs:
           EOF
 
           pip install copr-cli
-          REGEX='leapp-repository.*master.*' COPR_REPO='@oamg/leapp' _COPR_CONFIG=copr_fedora.conf python ${{ github.workspace }}/utils/get_latest_copr_build > latest_lpr
+          REGEX=$REGEX COPR_REPO=$COPR_REPO _COPR_CONFIG=$COPR_CONFIG python ${{ github.workspace }}/utils/get_latest_copr_build > latest_lpr
           COPR_ID=$(cat latest_lpr)
           echo "::set-output name=copr_id::${COPR_ID##*/}"
 
       - name: Trigger copr build
         id: copr_build
+        env:
+          COPR_CONFIG: "copr_fedora.conf"
+          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
         run: |
-          cat << EOF > copr_fedora.conf
+          cat << EOF > $COPR_CONFIG
           [copr-cli]
           login = ${{ secrets.FEDORA_COPR_LOGIN }}
           username = @oamg
@@ -73,7 +81,7 @@ jobs:
           EOF
 
           pip install copr-cli
-          PR=${{ steps.pr_nr.outputs.pr_nr }} COPR_CONFIG=copr_fedora.conf make copr_build | tee copr.log
+          PR=${{ steps.pr_nr.outputs.pr_nr }} COPR_CONFIG=$COPR_CONFIG COPR_CHROOT=$COPR_CHROOT make copr_build | tee copr.log
 
           COPR_URL=$(grep -Po 'https://copr.fedorainfracloud.org/coprs/build/\d+' copr.log)
           echo "::set-output name=copr_url::${COPR_URL}"
@@ -116,8 +124,11 @@ jobs:
       - name: Trigger copr build for leapp-repository
         id: copr_build_leapp_repository
         if: ${{ steps.leapp_repository_pr_regex_match.outputs.match != '' }}
+        env:
+          COPR_CONFIG: "copr_fedora.conf"
+          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
         run: |
-          cat << EOF > copr_fedora.conf
+          cat << EOF > $COPR_CONFIG
           [copr-cli]
           login = ${{ secrets.FEDORA_COPR_LOGIN }}
           username = @oamg
@@ -127,7 +138,7 @@ jobs:
           EOF
 
           pip install copr-cli
-          PR=${{ steps.leapp_repository_pr.outputs.leapp_repository_pr }} COPR_CONFIG=copr_fedora.conf make copr_build | tee copr.log
+          PR=${{ steps.leapp_repository_pr.outputs.leapp_repository_pr }} COPR_CHROOT=$COPR_CHROOT COPR_CONFIG=$COPR_CONFIG make copr_build | tee copr.log
 
           COPR_URL=$(grep -Po 'https://copr.fedorainfracloud.org/coprs/build/\d+' copr.log)
           echo "::set-output name=copr_url::${COPR_URL}"

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,15 @@ VERSION=`grep -m1 "^Version:" packaging/$(PKGNAME).spec | grep -om1 "[0-9].[0-9.
 # use it instead of the default
 _COPR_REPO=$${COPR_REPO:-leapp}
 _COPR_CONFIG=$${COPR_CONFIG:-~/.config/copr_rh_oamg.conf}
+# NOTE(ivasilev) Borrowed from leapp-repository's Makefile
+# In case just specific CHROOTs should be used for the COPR build, you can
+# set the multiple CHROOTs separated by comma in the COPR_CHROOT envar, e.g.
+# "epel-7-x86_64,epel-8-x86_64". But for the copr-cli utility, each of them
+# has to be specified separately for the -r option; So we transform it
+# automatically to "-r epel-7-x86_64 -r epel-8-x86_64" (without quotes).
+ifdef COPR_CHROOT
+	_COPR_CHROOT=`echo $${COPR_CHROOT} | grep -o "[^,]*" | sed "s/^/-r /g"`
+endif
 
 # just to reduce number of unwanted builds mark as the upstream one when
 # someone will call copr_build without additional parameters
@@ -105,9 +114,9 @@ srpm: source
 
 copr_build: srpm
 	@echo "--- Build RPM ${PKGNAME}-${VERSION}-${RELEASE}.el$(DIST_VERSION).rpm in COPR ---"
-	@echo copr-cli --config $(_COPR_CONFIG) build $(_COPR_REPO) \
+	@echo copr-cli --config $(_COPR_CONFIG) build $(_COPR_REPO) $(_COPR_CHROOT) \
 		packaging/SRPMS/${PKGNAME}-${VERSION}-${RELEASE}*.src.rpm
-	@copr-cli --config $(_COPR_CONFIG) build $(_COPR_REPO) \
+	@copr-cli --config $(_COPR_CONFIG) build $(_COPR_REPO) $(_COPR_CHROOT) \
 		packaging/SRPMS/${PKGNAME}-${VERSION}-${RELEASE}*.src.rpm
 
 print_release:


### PR DESCRIPTION
Instead of building for all project chroots use -r/--chroot
option to specify chroots.
Tmt-tests workflow and copr-build workflow will be passing proper
chroots now via COPR_CHROOT env var.
Also some refactoring has been done to the workflows to move all
magic constants to env section.

OAMG-6735