### PR TITLE
Preserve the original inhibitor detection valid for now

### DIFF
--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -326,6 +326,12 @@ def _create_report_object(entries):
     _sanitize_entries(entries)
     for entry in entries:
         entry.apply(report)
+    if Groups.INHIBITOR in report.get('groups', []):
+        # Before removing Flags, the original inhibitor detection worked
+        # by checking the `flags` field; keep the `flags` field until we drop Flags completely
+        # Currently we know that 'flags' does not exist otherwise so it's
+        # safe to just set it
+        report['flags'] = [Groups.INHIBITOR]
 
     return Report(report=report)
 

--- a/leapp/utils/report.py
+++ b/leapp/utils/report.py
@@ -139,4 +139,15 @@ def generate_report_file(messages_to_report, context, path, report_schema='1.1.0
                     groups = msg.pop('groups', [])
                     msg['flags'] = [g for g in groups if g in _DEPRECATION_FLAGS]
                     msg['tags'] = [g for g in groups if g not in _DEPRECATION_FLAGS]
+            if report_schema_tuple == (1, 2, 0):
+                # DEPRECATED: flags, tags
+                # NOTE(pstodulk): This is a temporary solution to ensure that
+                # flags are not present in the JSON output as we need to re-introduce
+                # flags internally to ensure that any inhibitor checks will not
+                # be negatively affected until we drop flags and tags completely.
+                messages_to_report = list(messages_to_report)
+                for msg in messages_to_report:
+                    # NOTE(ivasilev) As flags field is created only if there is an inhibitor
+                    # a default value to pop has to be specified not to end up with a KeyError
+                    msg.pop('flags', None)
             json.dump({'entries': messages_to_report, 'leapp_run_id': context}, f, indent=2)


### PR DESCRIPTION
As we substituted Tags and Flags with Groups recently, it has
impact on original detection of inhibitor inside leapp-repository
which is not compatible with the new reporting implementation.
As it could happen that new framework and old leapp-repository could
be installed on the system, the consequence in such a case is that
inhibitors will not be caught and user running:
```
  # leapp upgrade --reboot
```
could hit various serious issues. This change make sure we keep the
original functionality working, until we drop flags & tags
completely, providing enough time to everyone to adapt to new
changes.