### PR TITLE
api: Preserve environment variables when calling a command

### DIFF
--- a/leapp/libraries/stdlib/call.py
+++ b/leapp/libraries/stdlib/call.py
@@ -121,7 +121,7 @@ def _call(command, callback_raw=lambda fd, value: None, callback_linebuffered=la
     if not isinstance(read_buffer_size, int) or isinstance(read_buffer_size, bool) or read_buffer_size <= 0:
         raise ValueError('read_buffer_size parameter has to be integer greater than zero')
 
-    environ = os.environ
+    environ = os.environ.copy()
     if env:
         if not isinstance(env, dict):
             raise TypeError('env parameter has to be a dictionary')

--- a/tests/scripts/test_stdlib_call.py
+++ b/tests/scripts/test_stdlib_call.py
@@ -77,6 +77,16 @@ def test_env_injection():
     assert ret['stdout'] == 'SUCCESS\n'
 
 
+def test_env_preservation():
+    os.environ['TEST'] = 'FAILURE'
+    ret = _call(('bash', '-c', 'echo $TEST'), env={'TEST': 'SUCCESS', 'TEST2': 'HELLO_WORLD'})
+    assert isinstance(ret['exit_code'], int)
+    assert ret['exit_code'] == 0
+    assert 'TEST2' not in os.environ
+    assert os.environ['TEST'] == 'FAILURE'
+    assert ret['stdout'] == 'SUCCESS\n'
+
+
 def test_callability_check():
     with pytest.raises(TypeError):
         _call(('true',), callback_raw='nope')


### PR DESCRIPTION
When calling a command with `_call` and `env` parameter is not `None`,
create and modify a copy of caller process environment variables and
call the command with the copy in order to preserve them.

Jira ref: OAMG-7203