### PR TITLE
cli: Handle missing commands gracefully

### DIFF
--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -1,11 +1,12 @@
-
 import os
 import pkgutil
 import socket
 import sys
+import textwrap
 
 from leapp import VERSION
 from leapp.cli import commands
+from leapp.exceptions import UnknownCommandError
 from leapp.utils.clicmd import command
 
 
@@ -40,4 +41,13 @@ def main():
 
     os.environ['LEAPP_HOSTNAME'] = socket.getfqdn()
     _load_commands(cli.command)
-    cli.command.execute('leapp version {}'.format(VERSION))
+    try:
+        cli.command.execute('leapp version {}'.format(VERSION))
+    except UnknownCommandError as e:
+        print(textwrap.dedent('''
+        Command "{CMD}" is unknown.
+        Most likely there is a typo in the command or particular leapp repositories that provide this command
+        are not present on the system.
+        You can try to install the missing content e.g. by the following command: `dnf install 'leapp-command({CMD})'`
+        '''.format(CMD=e.requested)))
+        sys.exit(1)

--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -44,10 +44,13 @@ def main():
     try:
         cli.command.execute('leapp version {}'.format(VERSION))
     except UnknownCommandError as e:
-        print(textwrap.dedent('''
-        Command "{CMD}" is unknown.
-        Most likely there is a typo in the command or particular leapp repositories that provide this command
-        are not present on the system.
-        You can try to install the missing content e.g. by the following command: `dnf install 'leapp-command({CMD})'`
-        '''.format(CMD=e.requested)))
+        bad_cmd = (
+            "Command \"{CMD}\" is unknown.\nMost likely there is a typo in the command or particular "
+            "leapp repositories that provide this command are not present on the system.\n"
+            "You can try to install the missing content e.g. by the following command: "
+            "`dnf install 'leapp-command({CMD})'`")
+        if e.requested.startswith('-'):
+            # A quick ack not to confuse users with install a leapp-command(--some-wrong-argument) suggestion
+            bad_cmd = "No such argument {CMD}"
+        print(bad_cmd.format(CMD=e.requested))
         sys.exit(1)

--- a/leapp/exceptions.py
+++ b/leapp/exceptions.py
@@ -102,6 +102,12 @@ class CommandDefinitionError(LeappError):
     pass
 
 
+class UnknownCommandError(LeappError):
+    def __init__(self, command):
+        super().__init__('Unknown command: {}'.format(command))
+        self.requested = command
+
+
 class LeappRuntimeError(LeappError):
     pass
 


### PR DESCRIPTION
Previously when leapp was executed but no cli commands were installed,
the leapp execution failed with an exception.

This patch will add specific handling to this particular scenario and
return a 1 exit code.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>
Jira ref.: OAMG-7148