### PR TITLE
Deprecate Tags and Flags

### DIFF
--- a/docs/source/deprecation.md
+++ b/docs/source/deprecation.md
@@ -13,7 +13,11 @@ the leapp standard library, etc. But don't cover deprecated functionalities
 from particular leapp repositories (e.g. the [elt7toel8](https://github.com/oamg/leapp-repository/tree/master/repos/system_upgrade/el7toel8) leapp repository). For
 such information, see [Deprecated functionality in the el7toel8 repository](el7toel8/deprecation.html#deprecated-functionality-in-the-el7toel8-repository).
 
-*Note: No new deprecation present yet.*
+## current upstream development <span style="font-size:0.5em; font-weight:normal">(till the next release + 6months)</span>
+
+- Reporting primitives
+    - **`leapp.reporting.Flags`** - The `Flags` report primitive has been deprecated in favor of the more general `Groups` one.
+    - **`leapp.reporting.Tags`** - The `Tags` report primitive has been deprecated in favor of the more general `Groups` one.
 
 ## What is covered by deprecation process in leapp?
 

--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -9,6 +9,7 @@ from leapp.compat import string_types
 from leapp.models import fields, Model, ErrorModel
 from leapp.topics import ReportTopic
 from leapp.libraries.stdlib.api import produce
+from leapp.utils.deprecation import deprecated
 
 
 class Report(Model):
@@ -159,9 +160,29 @@ class Groups(BaseListPrimitive):
         self._value = value
 
 
-# To gradually switch from using Tags and Flags to using Groups make Tags and Flags aliases of Groups
-Tags = Groups
-Flags = Groups
+@deprecated(
+    since='2022-09-01',
+    message=(
+        'The primitive is deprecated as Tags and Flags have been joined into the Groups primitive.'
+        'Please use Groups for report message typing instead.'
+    )
+)
+class Tags(Groups):
+    def __init__(self, *args, **kwargs):
+        super(Tags, self).__init__(*args, **kwargs)
+
+
+@deprecated(
+    since='2022-09-01',
+    message=(
+        'The primitive is deprecated as Tags and Flags have been joined into the Groups primitive.'
+        'Please use Groups for report message typing instead.'
+    )
+)
+class Flags(Groups):
+    def __init__(self, *args, **kwargs):
+        super(Flags, self).__init__(*args, **kwargs)
+
 
 # To allow backwards-compatibility with previous report-schema
 # Groups that match _DEPRECATION_FLAGS will be shown as flags, the rest as tags


### PR DESCRIPTION
Apply official deprecation process for Tags and Flags
primitives that has been superseeded by Groups.

OAMG-7262