### PR TITLE
Introduce a Blob model field

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 3.0
+%global framework_version 3.1
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage

--- a/tests/scripts/test_serialization.py
+++ b/tests/scripts/test_serialization.py
@@ -41,6 +41,12 @@ class WithNestedListModel(Model):
     items = fields.List(fields.Model(BasicModel))
 
 
+class WithBlobModel(Model):
+    topic = ModelTestTopic
+    message = fields.Blob()
+    can_be_empty = fields.Nullable(fields.Blob())
+
+
 class AllFieldTypesModel(Model):
     topic = ModelTestTopic
     float_field = fields.Float(default=3.14)
@@ -71,6 +77,12 @@ def test_base_usage():
 def test_basic_model():
     m = BasicModel(message='Some message')
     m2 = BasicModel.create(m.dump())
+    assert m.message == m2.message
+
+
+def test_bytestring_model():
+    m = WithBlobModel(message=b'\xf3\xcf\xcf\xc2\xdd\xc5\xce\xc9\xc5')
+    m2 = WithBlobModel.create(m.dump())
     assert m.message == m2.message
 
 


### PR DESCRIPTION
As models have to be JSON-serializable and byte
fields apparently don't fit in, let's introduce
a special model field type that could be used in
such situations.

OAMG-4306