### PR TITLE
Add Makefile target for building RPMs locally and in containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ res/schema/schemas.py
 leapp.db
 # do not ignore the directory with tests...
 !tests/scripts/
+
+packaging/BUILD/
+packaging/RPMS/
+packaging/SRPMS/
+packaging/sources/

--- a/res/container-builds/Containerfile.centos7
+++ b/res/container-builds/Containerfile.centos7
@@ -1,0 +1,11 @@
+FROM centos:7
+
+VOLUME /payload
+
+ENV DIST_VERSION 7
+
+RUN yum update -y && \
+    yum install -y make git rpm-build python-setuptools python-devel
+
+WORKDIR /payload
+ENTRYPOINT make build

--- a/res/container-builds/Containerfile.fedora_generic
+++ b/res/container-builds/Containerfile.fedora_generic
@@ -1,0 +1,12 @@
+# FROM statement is inserted in Makefile
+
+VOLUME /payload
+
+ENV DIST_VERSION 8
+
+RUN dnf update -y && \
+    dnf install -y python3 make git rpm-build python3-devel
+    #yum install -y python3-pip && \ python3 -m pip install --upgrade pip==20.3.4
+
+WORKDIR /payload
+ENTRYPOINT make build

--- a/res/container-builds/Containerfile.ubi8
+++ b/res/container-builds/Containerfile.ubi8
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+VOLUME /payload
+
+ENV DIST_VERSION 8
+
+RUN dnf update -y && \
+    dnf install -y python3 make git rpm-build python3-devel
+    #yum install -y python3-pip && \ python3 -m pip install --upgrade pip==20.3.4
+
+WORKDIR /payload
+ENTRYPOINT make build


### PR DESCRIPTION
Add `build` target to build locally and `build_container` to build
locally in a container. Building in containers has the benefit of being
able to build on all the different platforms e.g. both on  el7 and el8.

Run `make build` to build locally.

Run `make build_container` to build in a container. Note that
BUILD_CONTAINER environment variable must be set.

Run `clean_containers` to clean up container images used for building.

The containers are built from Containerfiles in `res/container-builds/`.
Since Containerfiles for all the Fedora versions would differ only in the `FROM`
statement, a generic Containerfile `Containerfile.fedora_generic` is
used and the `FROM` statement is inserted in the Makefile.

For el7 builds CentOS 7 container is used, because rpm-build package
is not available in ubi7 image.

Builds cannot be run in parallel because containers operate on the same
files, which would result in them conflicting.

Also update `.gitignore` to exclude build files from git.

Jira ref: OAMG-2251