### PR TITLE
Be more specific about distro

### DIFF
--- a/.github/workflows/reuse-tests-7to8.yml
+++ b/.github/workflows/reuse-tests-7to8.yml
@@ -28,7 +28,7 @@ on:
         default: 'epel-7-x86_64'
       tmt_context:
         type: string
-        default: 'distro=rhel-7'
+        default: 'distro=rhel-7.9'
       compose:
         type: string
         default: 'RHEL-7.9-ZStream'

--- a/.github/workflows/reuse-tests-8to9.yml
+++ b/.github/workflows/reuse-tests-8to9.yml
@@ -28,7 +28,7 @@ on:
         default: 'epel-8-x86_64'
       tmt_context:
         type: string
-        default: 'distro=rhel-8'
+        default: 'distro=rhel-8.6'
       compose:
         type: string
         default: 'RHEL-8.6.0-Nightly'

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -74,6 +74,7 @@ jobs:
       variables: 'LEAPP_DEVEL_TARGET_PRODUCT_TYPE=beta;RHSM_SKU=RH00069;TARGET_RELEASE=9.1;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms'
       compose: 'RHEL-8.7.0-Nightly'
       pull_request_status_name: "8.7to9.1"
+      tmt_context: "distro=rhel-8.7"
 
   call_workflow_tests_86to90_sst:
     needs: call_workflow_copr_build


### PR DESCRIPTION
Instead of vague distro=7 and distro=8 use
7.9 and 8.6 respectedly as our refactored regression
tests now use.
This should fix the "no plans found" issue with 8.6-rhui
upgrade as well as continue running e2e test as part of
8->9 integration tests.