### PR TITLE
Release 0.15.0

### DIFF
--- a/docs/source/deprecation.md
+++ b/docs/source/deprecation.md
@@ -15,6 +15,10 @@ such information, see [Deprecated functionality in the el7toel8 repository](el7t
 
 ## current upstream development <span style="font-size:0.5em; font-weight:normal">(till the next release + 6months)</span>
 
+- nothing yet...
+
+## current upstream development <span style="font-size:0.5em; font-weight:normal">(till Mar 2023)</span>
+
 - Reporting primitives
     - **`leapp.reporting.Flags`** - The `Flags` report primitive has been deprecated in favor of the more general `Groups` one.
     - **`leapp.reporting.Tags`** - The `Tags` report primitive has been deprecated in favor of the more general `Groups` one.

--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,6 +1,6 @@
 from leapp.utils.workarounds import apply_workarounds
 
-VERSION = "0.14.0"
+VERSION = "0.15.0"
 FULL_VERSION = VERSION
 
 apply_workarounds()

--- a/leapp/reporting/__init__.py
+++ b/leapp/reporting/__init__.py
@@ -161,7 +161,7 @@ class Groups(BaseListPrimitive):
 
 
 @deprecated(
-    since='2022-09-01',
+    since='2022-08-23',
     message=(
         'The primitive is deprecated as Tags and Flags have been joined into the Groups primitive.'
         'Please use Groups for report message typing instead.'
@@ -173,7 +173,7 @@ class Tags(Groups):
 
 
 @deprecated(
-    since='2022-09-01',
+    since='2022-08-23',
     message=(
         'The primitive is deprecated as Tags and Flags have been joined into the Groups primitive.'
         'Please use Groups for report message typing instead.'

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,4 +1,4 @@
-.TH LEAPP "1" "2022-03-17" "leapp 0.14.0" "User Commands"
+.TH LEAPP "1" "2022-08-23" "leapp 0.15.0" "User Commands"
 
 .SH NAME
 leapp \- command line interface for upgrades between major OS versions

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,4 +1,4 @@
-.TH SNACTOR "1" "2022-03-17" "snactor 0.14.0" "User Commands"
+.TH SNACTOR "1" "2022-08-23" "snactor 0.15.0" "User Commands"
 
 .SH NAME
 snactor \- development and repository management tool for leapp

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -42,7 +42,7 @@
 %endif
 
 Name:       leapp
-Version:    0.14.0
+Version:    0.15.0
 Release:    1%{?dist}
 Summary:    OS & Application modernization framework
 


### PR DESCRIPTION
## Packaging
-  bumped leapp-framework to 3.1 (#677)

## Framework

### Fixes
- Fixed a problem where passing environment variables to an executed child process modified the environment variables of the parent process (​​#784)
- Ignore invalid FQDNs (#790)

### Enhancements
- Deprecate `reporting.(Tags|Flags)`, replaced by `reporting.Groups` (#677, #781, #788)
- Introduce `is_inhibitor` function (#677)
- Introduce a `Blob` model field (#789)
- Introduce new report JSON schema v1.2.0 (default: 1.1.0) (#677)

## Leapp (tool)

### Fixes
- Handle missing CLI commands gracefully (#785)
- Requires to be executed by root only (#775)