### PR TITLE
Expose tracebacks from actor exceptions

### DIFF
--- a/leapp/exceptions.py
+++ b/leapp/exceptions.py
@@ -109,7 +109,7 @@ class UnknownCommandError(LeappError):
 
 
 class LeappRuntimeError(LeappError):
-    def __init__(self, message, exception_info):
+    def __init__(self, message, exception_info=None):
         super().__init__(message)
         self.exception_info = exception_info
 

--- a/leapp/exceptions.py
+++ b/leapp/exceptions.py
@@ -104,13 +104,13 @@ class CommandDefinitionError(LeappError):
 
 class UnknownCommandError(LeappError):
     def __init__(self, command):
-        super().__init__('Unknown command: {}'.format(command))
+        super(UnknownCommandError, self).__init__('Unknown command: {}'.format(command))
         self.requested = command
 
 
 class LeappRuntimeError(LeappError):
     def __init__(self, message, exception_info=None):
-        super().__init__(message)
+        super(LeappRuntimeError, self).__init__(message)
         self.exception_info = exception_info
 
 

--- a/leapp/exceptions.py
+++ b/leapp/exceptions.py
@@ -109,7 +109,9 @@ class UnknownCommandError(LeappError):
 
 
 class LeappRuntimeError(LeappError):
-    pass
+    def __init__(self, message, exception_info):
+        super().__init__(message)
+        self.exception_info = exception_info
 
 
 class StopActorExecution(Exception):


### PR DESCRIPTION
Previously when leapp would be running actors, any exceptions raised by
those actors in child processes would only be output to stderr,
while the main process would only have the exit code to examine.

Consequently, there was no real way to log occurring exceptions -
only providing the aforementioned exit code was possible.

This patch adds a pipe between the main and the actor processes,
through which a formatted exception + traceback string is provided to
the main process.
This string is then packaged into the `LeappRuntimeError` thrown from the
process, to be utilized downstream in
workflow/command code.

This should serve as a step to closing #692 - although actually logging
the exception traceback likely should be done on the `leapp-repository` side. 