### PR TITLE
Upgrade packit.yaml config to have integration tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -54,7 +54,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to84
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys;curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
@@ -66,7 +66,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to84-sst
   tmt_plan: "^(/plans/morf)(?!.*sap)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys;curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
   env: 
     TARGET_RELEASE: 8.6
 
@@ -80,7 +80,7 @@ jobs:
       distros: [RHEL-7.9-rhui]
   identifier: tests-7to8-aws
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms;  yum install -y leapp-repository*master*"
   env: 
     RHUI: "aws"
 
@@ -94,7 +94,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to86
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys;curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
   env: 
     TARGET_RELEASE: 8.6
 
@@ -108,7 +108,7 @@ jobs:
       distros: [RHEL-8.6-rhui]
   identifier: tests-8to9-aws
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
   env:
     RHUI: aws
 
@@ -122,7 +122,7 @@ jobs:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-86to90
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
   env:
     TARGET_RELEASE: "9.0"
     TARGET_KERNEL: el9
@@ -138,7 +138,7 @@ jobs:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-86to90-sst
   tmt_plan: "^(/plans/morf)(?!.*sap)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
   env:
     TARGET_RELEASE: "9.0"
     TARGET_KERNEL: el9
@@ -154,7 +154,7 @@ jobs:
       distros: [RHEL-8.7.0-Nightly]
   identifier: tests-87to91
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
   env:
     LEAPP_DEVEL_TARGET_PRODUCT_TYPE: beta
     RHSM_SKU: RH00069

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -59,8 +59,8 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            distro: "rhel-7.9"
+            context:
+              distro: "rhel-7.9"
     env:
       SOURCE_RELEASE: "7.9"
       TARGET_RELEASE: "8.6"
@@ -79,8 +79,8 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            distro: "rhel-7.9"
+            context:
+              distro: "rhel-7.9"
     env:
       SOURCE_RELEASE: "7.9"
       TARGET_RELEASE: "8.8"
@@ -99,8 +99,8 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            distro: "rhel-7.9"
+            context:
+              distro: "rhel-7.9"
     env:
       SOURCE_RELEASE: "7.9"
       TARGET_RELEASE: "8.8"
@@ -119,8 +119,8 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            distro: "rhel-7.9"
+            context:
+              distro: "rhel-7.9"
     env:
       SOURCE_RELEASE: "7.9"
       TARGET_RELEASE: "8.6"
@@ -140,8 +140,8 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            distro: "rhel-8.6"
+            context:
+              distro: "rhel-8.6"
     env:
       SOURCE_RELEASE: "8.6"
       TARGET_RELEASE: "9.0"
@@ -162,8 +162,8 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            distro: "rhel-8.7"
+            context:
+              distro: "rhel-8.7"
     env:
       SOURCE_RELEASE: "8.7"
       TARGET_RELEASE: "9.0"
@@ -184,8 +184,8 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            distro: "rhel-8.6"
+            context:
+              distro: "rhel-8.6"
     env:
       SOURCE_RELEASE: "8.6"
       TARGET_RELEASE: "9.0"
@@ -206,8 +206,8 @@ jobs:
     tf_extra_params:
       environments:
         - tmt:
-          context:
-            distro: "rhel-8.6"
+            context:
+              distro: "rhel-8.6"
     env:
       SOURCE_RELEASE: "8.6"
       TARGET_RELEASE: "9.0"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -45,7 +45,7 @@ jobs:
     - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
 
 - job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
@@ -57,7 +57,7 @@ jobs:
   tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys;curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
 
 - job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
@@ -71,7 +71,7 @@ jobs:
     TARGET_RELEASE: 8.6
 
 - job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
@@ -85,7 +85,7 @@ jobs:
     RHUI: "aws"
 
 - job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
@@ -99,7 +99,7 @@ jobs:
     TARGET_RELEASE: 8.6
 
 - job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
@@ -113,7 +113,7 @@ jobs:
     RHUI: aws
 
 - job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
@@ -129,7 +129,7 @@ jobs:
     RHSM_REPOS: rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms
 
 - job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
@@ -145,7 +145,7 @@ jobs:
     RHSM_REPOS: rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms
 
 - job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -24,6 +24,7 @@ jobs:
     get-current-version:
     # get version from spec file instead from git tag
     - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
+
 - job: copr_build
   trigger: commit
   metadata:
@@ -44,6 +45,7 @@ jobs:
     # get version from spec file instead from git tag
     - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
 
+
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "master"
@@ -54,7 +56,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to84
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
@@ -66,7 +68,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to84-sst
   tmt_plan: "^(/plans/morf)(?!.*sap)"
-  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
   env: 
     TARGET_RELEASE: 8.6
 
@@ -80,7 +82,7 @@ jobs:
       distros: [RHEL-7.9-rhui]
   identifier: tests-7to8-aws
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
-  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms; yum install -y \"leapp-upgrade*master*\"'
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
   env: 
     RHUI: "aws"
 
@@ -94,7 +96,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to86
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
   env: 
     TARGET_RELEASE: 8.6
 
@@ -108,7 +110,7 @@ jobs:
       distros: [RHEL-8.6-rhui]
   identifier: tests-8to9-aws
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
-  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
   env:
     RHUI: aws
 
@@ -122,7 +124,7 @@ jobs:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-86to90
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
   env:
     TARGET_RELEASE: "9.0"
     TARGET_KERNEL: el9
@@ -138,7 +140,7 @@ jobs:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-86to90-sst
   tmt_plan: "^(/plans/morf)(?!.*sap)"
-  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
   env:
     TARGET_RELEASE: "9.0"
     TARGET_KERNEL: el9
@@ -154,7 +156,7 @@ jobs:
       distros: [RHEL-8.7.0-Nightly]
   identifier: tests-87to91
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
   env:
     LEAPP_DEVEL_TARGET_PRODUCT_TYPE: beta
     RHSM_SKU: RH00069

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,3 +43,121 @@ jobs:
     get-current-version:
     # get version from spec file instead from git tag
     - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "main"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-79to84
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys;curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "main"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-79to84-sst
+  tmt_plan: "^(/plans/morf)(?!.*sap)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys;curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  env: 
+    TARGET_RELEASE: 8.6
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "main"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-rhui]
+  identifier: tests-7to8-aws
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  env: 
+    RHUI: "aws"
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "main"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-79to86
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys;curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  env: 
+    TARGET_RELEASE: 8.6
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "main"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.6-rhui]
+  identifier: tests-8to9-aws
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  env:
+    RHUI: aws
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "main"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.6.0-Nightly]
+  identifier: tests-86to90
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  env:
+    TARGET_RELEASE: "9.0"
+    TARGET_KERNEL: el9
+    RHSM_REPOS: rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "main"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.6.0-Nightly]
+  identifier: tests-86to90-sst
+  tmt_plan: "^(/plans/morf)(?!.*sap)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  env:
+    TARGET_RELEASE: "9.0"
+    TARGET_KERNEL: el9
+    RHSM_REPOS: rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "main"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.7.0-Nightly]
+  identifier: tests-87to91
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp*master*"
+  env:
+    LEAPP_DEVEL_TARGET_PRODUCT_TYPE: beta
+    RHSM_SKU: RH00069
+    TARGET_RELEASE: "9.1"
+    TARGET_KERNEL: el9
+    RHSM_REPOS: rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,211 +6,206 @@ merge_pr_in_ci: false
 srpm_build_deps: []
 
 jobs:
-  - job: copr_build
-    trigger: pull_request
-    metadata:
-      owner: "@oamg"
-      project: leapp
-      targets:
-        - epel-7-ppc64le
-        - epel-7-x86_64
-        - epel-8-x86_64
-        - fedora-all-aarch64
-        - fedora-all-x86_64
-    actions:
-      post-upstream-clone:
-        # builds from PRs should have lower NVR than those from master branch
-        - sed -i "s/1%{?dist}/0%{?dist}/g" packaging/leapp.spec
-      get-current-version:
-        # get version from spec file instead from git tag
-        - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
-
-  - job: copr_build
-    trigger: commit
-    metadata:
-      branch: master
-      owner: "@oamg"
-      project: leapp
-      targets:
-        - epel-7-ppc64le
-        - epel-7-x86_64
-        - epel-8-x86_64
-        - fedora-all-aarch64
-        - fedora-all-x86_64
-    actions:
-      post-upstream-clone:
-        # builds from master branch should have the highest NVR
-        - sed -i "s/1%{?dist}/100%{?dist}/g" packaging/leapp.spec
-      get-current-version:
-        # get version from spec file instead from git tag
-        - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
-
-  - job: tests
-    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-    fmf_ref: "master"
-    use_internal_tf: True
-    trigger: pull_request
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    owner: "@oamg"
+    project: leapp
     targets:
-      epel-7-x86_64:
-        distros: [RHEL-7.9-ZStream]
-    identifier: tests-7.9to8.6
-    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "rhel-7.9"
-    env:
-      SOURCE_RELEASE: "7.9"
-      TARGET_RELEASE: "8.6"
-
-  - job: tests
-    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-    fmf_ref: "master"
-    use_internal_tf: True
-    trigger: pull_request
+    - epel-7-ppc64le
+    - epel-7-x86_64
+    - epel-8-x86_64
+    - fedora-all-aarch64
+    - fedora-all-x86_64
+  actions:
+    post-upstream-clone:
+    # builds from PRs should have lower NVR than those from master branch
+    - sed -i "s/1%{?dist}/0%{?dist}/g" packaging/leapp.spec
+    get-current-version:
+    # get version from spec file instead from git tag
+    - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
+- job: copr_build
+  trigger: commit
+  metadata:
+    branch: master
+    owner: "@oamg"
+    project: leapp
     targets:
-      epel-7-x86_64:
-        distros: [RHEL-7.9-ZStream]
-    identifier: tests-7.9to8.8
-    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "rhel-7.9"
-    env:
-      SOURCE_RELEASE: "7.9"
-      TARGET_RELEASE: "8.8"
+    - epel-7-ppc64le
+    - epel-7-x86_64
+    - epel-8-x86_64
+    - fedora-all-aarch64
+    - fedora-all-x86_64
+  actions:
+    post-upstream-clone:
+    # builds from master branch should have the highest NVR
+    - sed -i "s/1%{?dist}/100%{?dist}/g" packaging/leapp.spec
+    get-current-version:
+    # get version from spec file instead from git tag
+    - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
 
-  - job: tests
-    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-    fmf_ref: "master"
-    use_internal_tf: True
-    trigger: pull_request
-    targets:
-      epel-7-x86_64:
-        distros: [RHEL-7.9-ZStream]
-    identifier: tests-7.9to8.8-sst
-    tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "rhel-7.9"
-    env:
-      SOURCE_RELEASE: "7.9"
-      TARGET_RELEASE: "8.8"
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-7.9to8.6
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-7.9"
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.6"
 
-  - job: tests
-    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-    fmf_ref: "master"
-    use_internal_tf: True
-    trigger: pull_request
-    targets:
-      epel-7-x86_64:
-        distros: [RHEL-7.9-rhui]
-    identifier: tests-7to8-aws-e2e
-    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "rhel-7.9"
-    env:
-      SOURCE_RELEASE: "7.9"
-      TARGET_RELEASE: "8.6"
-      RHUI: "aws"
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-7.9to8.8
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-7.9"
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.8"
 
-  - job: tests
-    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-    fmf_ref: "master"
-    use_internal_tf: True
-    trigger: pull_request
-    targets:
-      epel-8-x86_64:
-        distros: [RHEL-8.6.0-Nightly]
-    identifier: tests-8.6to9.0
-    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "rhel-8.6"
-    env:
-      SOURCE_RELEASE: "8.6"
-      TARGET_RELEASE: "9.0"
-      TARGET_KERNEL: "el9"
-      RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
+# - job: tests
+#   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+#   fmf_ref: "master"
+#   use_internal_tf: True
+#   trigger: pull_request
+#   targets:
+#     epel-7-x86_64:
+#       distros: [RHEL-7.9-ZStream]
+#   identifier: tests-7.9to8.8-sst
+#   tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
+#   tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+#   tf_extra_params:
+#     environments:
+#       - tmt:
+#           context:
+#             distro: "rhel-7.9"
+#   env:
+#     SOURCE_RELEASE: "7.9"
+#     TARGET_RELEASE: "8.8"
 
-  - job: tests
-    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-    fmf_ref: "master"
-    use_internal_tf: True
-    trigger: pull_request
-    targets:
-      epel-8-x86_64:
-        distros: [RHEL-8.7.0-Nightly]
-    identifier: tests-8.7to9.0
-    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "rhel-8.7"
-    env:
-      SOURCE_RELEASE: "8.7"
-      TARGET_RELEASE: "9.0"
-      TARGET_KERNEL: "el9"
-      RHSM_REPOS: "rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms"
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-rhui]
+  identifier: tests-7to8-aws-e2e
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-7.9"
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.6"
+    RHUI: "aws"
 
-  - job: tests
-    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-    fmf_ref: "master"
-    use_internal_tf: True
-    trigger: pull_request
-    targets:
-      epel-8-x86_64:
-        distros: [RHEL-8.6.0-Nightly]
-    identifier: tests-8.6to9.0-sst
-    tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "rhel-8.6"
-    env:
-      SOURCE_RELEASE: "8.6"
-      TARGET_RELEASE: "9.0"
-      TARGET_KERNEL: "el9"
-      RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.6.0-Nightly]
+  identifier: tests-8.6to9.0
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.6"
+  env:
+    SOURCE_RELEASE: "8.6"
+    TARGET_RELEASE: "9.0"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
 
-  - job: tests
-    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-    fmf_ref: "master"
-    use_internal_tf: True
-    trigger: pull_request
-    targets:
-      epel-8-x86_64:
-        distros: [RHEL-8.6-rhui]
-    identifier: tests-8to9-aws-e2e
-    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-    tf_extra_params:
-      environments:
-        - tmt:
-            context:
-              distro: "rhel-8.6"
-    env:
-      SOURCE_RELEASE: "8.6"
-      TARGET_RELEASE: "9.0"
-      TARGET_KERNEL: "el9"
-      RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
-      RHUI: "aws"
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.8.0-Nightly]
+  identifier: tests-8.8to9.2
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.8"
+  env:
+    SOURCE_RELEASE: "8.8"
+    TARGET_RELEASE: "9.2"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms"
+
+# - job: tests
+#   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+#   fmf_ref: "master"
+#   use_internal_tf: True
+#   trigger: pull_request
+#   targets:
+#     epel-8-x86_64:
+#       distros: [RHEL-8.6.0-Nightly]
+#   identifier: tests-8.6to9.0-sst
+#   tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
+#   tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+#   tf_extra_params:
+#     environments:
+#       - tmt:
+#           context:
+#             distro: "rhel-8.6"
+#   env:
+#     SOURCE_RELEASE: "8.6"
+#     TARGET_RELEASE: "9.0"
+#     RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
+
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.6-rhui]
+  identifier: tests-8to9-aws-e2e
+  tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
+  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.6"
+  env:
+    SOURCE_RELEASE: "8.6"
+    TARGET_RELEASE: "9.0"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
+    RHUI: "aws"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,160 +6,211 @@ merge_pr_in_ci: false
 srpm_build_deps: []
 
 jobs:
-- job: copr_build
-  trigger: pull_request
-  metadata:
-    owner: "@oamg"
-    project: leapp
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      owner: "@oamg"
+      project: leapp
+      targets:
+        - epel-7-ppc64le
+        - epel-7-x86_64
+        - epel-8-x86_64
+        - fedora-all-aarch64
+        - fedora-all-x86_64
+    actions:
+      post-upstream-clone:
+        # builds from PRs should have lower NVR than those from master branch
+        - sed -i "s/1%{?dist}/0%{?dist}/g" packaging/leapp.spec
+      get-current-version:
+        # get version from spec file instead from git tag
+        - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
+
+  - job: copr_build
+    trigger: commit
+    metadata:
+      branch: master
+      owner: "@oamg"
+      project: leapp
+      targets:
+        - epel-7-ppc64le
+        - epel-7-x86_64
+        - epel-8-x86_64
+        - fedora-all-aarch64
+        - fedora-all-x86_64
+    actions:
+      post-upstream-clone:
+        # builds from master branch should have the highest NVR
+        - sed -i "s/1%{?dist}/100%{?dist}/g" packaging/leapp.spec
+      get-current-version:
+        # get version from spec file instead from git tag
+        - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
+
+  - job: tests
+    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+    fmf_ref: "master"
+    use_internal_tf: True
+    trigger: pull_request
     targets:
-    - epel-7-ppc64le
-    - epel-7-x86_64
-    - epel-8-x86_64
-    - fedora-all-aarch64
-    - fedora-all-x86_64
-  actions:
-    post-upstream-clone:
-    # builds from PRs should have lower NVR than those from master branch
-    - sed -i "s/1%{?dist}/0%{?dist}/g" packaging/leapp.spec
-    get-current-version:
-    # get version from spec file instead from git tag
-    - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
+      epel-7-x86_64:
+        distros: [RHEL-7.9-ZStream]
+    identifier: tests-7.9to8.6
+    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_extra_params:
+      environments:
+        - tmt:
+          context:
+            distro: "rhel-7.9"
+    env:
+      SOURCE_RELEASE: "7.9"
+      TARGET_RELEASE: "8.6"
 
-- job: copr_build
-  trigger: commit
-  metadata:
-    branch: master
-    owner: "@oamg"
-    project: leapp
+  - job: tests
+    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+    fmf_ref: "master"
+    use_internal_tf: True
+    trigger: pull_request
     targets:
-    - epel-7-ppc64le
-    - epel-7-x86_64
-    - epel-8-x86_64
-    - fedora-all-aarch64
-    - fedora-all-x86_64
-  actions:
-    post-upstream-clone:
-    # builds from master branch should have the highest NVR
-    - sed -i "s/1%{?dist}/100%{?dist}/g" packaging/leapp.spec
-    get-current-version:
-    # get version from spec file instead from git tag
-    - bash -c "grep -m1 '^Version:' packaging/leapp.spec | grep -om1 '[0-9].[0-9.]**'"
+      epel-7-x86_64:
+        distros: [RHEL-7.9-ZStream]
+    identifier: tests-7.9to8.8
+    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_extra_params:
+      environments:
+        - tmt:
+          context:
+            distro: "rhel-7.9"
+    env:
+      SOURCE_RELEASE: "7.9"
+      TARGET_RELEASE: "8.8"
 
+  - job: tests
+    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+    fmf_ref: "master"
+    use_internal_tf: True
+    trigger: pull_request
+    targets:
+      epel-7-x86_64:
+        distros: [RHEL-7.9-ZStream]
+    identifier: tests-7.9to8.8-sst
+    tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_extra_params:
+      environments:
+        - tmt:
+          context:
+            distro: "rhel-7.9"
+    env:
+      SOURCE_RELEASE: "7.9"
+      TARGET_RELEASE: "8.8"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-ZStream]
-  identifier: tests-79to84
-  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+  - job: tests
+    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+    fmf_ref: "master"
+    use_internal_tf: True
+    trigger: pull_request
+    targets:
+      epel-7-x86_64:
+        distros: [RHEL-7.9-rhui]
+    identifier: tests-7to8-aws-e2e
+    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
+    tf_extra_params:
+      environments:
+        - tmt:
+          context:
+            distro: "rhel-7.9"
+    env:
+      SOURCE_RELEASE: "7.9"
+      TARGET_RELEASE: "8.6"
+      RHUI: "aws"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-ZStream]
-  identifier: tests-79to84-sst
-  tmt_plan: "^(/plans/morf)(?!.*sap)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-  env: 
-    TARGET_RELEASE: 8.6
+  - job: tests
+    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+    fmf_ref: "master"
+    use_internal_tf: True
+    trigger: pull_request
+    targets:
+      epel-7-x86_64:
+        distros: [RHEL-8.6.0-Nightly]
+    identifier: tests-8.6to9.0
+    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_extra_params:
+      environments:
+        - tmt:
+          context:
+            distro: "rhel-8.6"
+    env:
+      SOURCE_RELEASE: "8.6"
+      TARGET_RELEASE: "9.0"
+      TARGET_KERNEL: "el9"
+      RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-rhui]
-  identifier: tests-7to8-aws
-  tmt_plan: "^(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
-  env: 
-    RHUI: "aws"
+  - job: tests
+    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+    fmf_ref: "master"
+    use_internal_tf: True
+    trigger: pull_request
+    targets:
+      epel-7-x86_64:
+        distros: [RHEL-8.7.0-Nightly]
+    identifier: tests-8.7to9.0
+    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_extra_params:
+      environments:
+        - tmt:
+          context:
+            distro: "rhel-8.7"
+    env:
+      SOURCE_RELEASE: "8.7"
+      TARGET_RELEASE: "9.0"
+      TARGET_KERNEL: "el9"
+      RHSM_REPOS: "rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-ZStream]
-  identifier: tests-79to86
-  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-  env: 
-    TARGET_RELEASE: 8.6
+  - job: tests
+    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+    fmf_ref: "master"
+    use_internal_tf: True
+    trigger: pull_request
+    targets:
+      epel-7-x86_64:
+        distros: [RHEL-8.6.0-Nightly]
+    identifier: tests-8.6to9.0-sst
+    tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_extra_params:
+      environments:
+        - tmt:
+          context:
+            distro: "rhel-8.6"
+    env:
+      SOURCE_RELEASE: "8.6"
+      TARGET_RELEASE: "9.0"
+      TARGET_KERNEL: "el9"
+      RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.6-rhui]
-  identifier: tests-8to9-aws
-  tmt_plan: "^(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-  env:
-    RHUI: aws
-
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.6.0-Nightly]
-  identifier: tests-86to90
-  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-  env:
-    TARGET_RELEASE: "9.0"
-    TARGET_KERNEL: el9
-    RHSM_REPOS: rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms
-
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.6.0-Nightly]
-  identifier: tests-86to90-sst
-  tmt_plan: "^(/plans/morf)(?!.*sap)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-  env:
-    TARGET_RELEASE: "9.0"
-    TARGET_KERNEL: el9
-    RHSM_REPOS: rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms
-
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.7.0-Nightly]
-  identifier: tests-87to91
-  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-  env:
-    LEAPP_DEVEL_TARGET_PRODUCT_TYPE: beta
-    RHSM_SKU: RH00069
-    TARGET_RELEASE: "9.1"
-    TARGET_KERNEL: el9
-    RHSM_REPOS: rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms
+  - job: tests
+    fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+    fmf_ref: "master"
+    use_internal_tf: True
+    trigger: pull_request
+    targets:
+      epel-7-x86_64:
+        distros: [RHEL-8.6-rhui]
+    identifier: tests-8to9-aws-e2e
+    tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_extra_params:
+      environments:
+        - tmt:
+          context:
+            distro: "rhel-8.6"
+    env:
+      SOURCE_RELEASE: "8.6"
+      TARGET_RELEASE: "9.0"
+      TARGET_KERNEL: "el9"
+      RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
+      RHUI: "aws"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -81,7 +81,7 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-rhui]
   identifier: tests-7to8-aws
-  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
+  tmt_plan: "^(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
   tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
   env: 
     RHUI: "aws"
@@ -109,7 +109,7 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.6-rhui]
   identifier: tests-8to9-aws
-  tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
+  tmt_plan: "^(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
   tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
   env:
     RHUI: aws

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -84,6 +84,7 @@ jobs:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
 
+
 # - job: tests
 #   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
 #   fmf_ref: "master"
@@ -165,7 +166,8 @@ jobs:
   env:
     SOURCE_RELEASE: "8.8"
     TARGET_RELEASE: "9.2"
-    RHSM_REPOS: "rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
+    LEAPP_DEVEL_TARGET_RELEASE: "9.2"
 
 # - job: tests
 #   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -46,7 +46,7 @@ jobs:
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "main"
+  fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   targets:
@@ -58,7 +58,7 @@ jobs:
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "main"
+  fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   targets:
@@ -72,7 +72,7 @@ jobs:
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "main"
+  fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   targets:
@@ -86,7 +86,7 @@ jobs:
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "main"
+  fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   targets:
@@ -100,7 +100,7 @@ jobs:
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "main"
+  fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   targets:
@@ -114,7 +114,7 @@ jobs:
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "main"
+  fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   targets:
@@ -130,7 +130,7 @@ jobs:
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "main"
+  fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   targets:
@@ -146,7 +146,7 @@ jobs:
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "main"
+  fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   targets:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,7 +55,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.6
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
     tf_extra_params:
       environments:
         - tmt:
@@ -75,7 +75,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.8
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
     tf_extra_params:
       environments:
         - tmt:
@@ -95,7 +95,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.8-sst
     tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
     tf_extra_params:
       environments:
         - tmt:
@@ -115,7 +115,7 @@ jobs:
         distros: [RHEL-7.9-rhui]
     identifier: tests-7to8-aws-e2e
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms; yum install -y \"leapp-upgrade*master*\""
     tf_extra_params:
       environments:
         - tmt:
@@ -136,7 +136,7 @@ jobs:
         distros: [RHEL-8.6.0-Nightly]
     identifier: tests-8.6to9.0
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
     tf_extra_params:
       environments:
         - tmt:
@@ -158,7 +158,7 @@ jobs:
         distros: [RHEL-8.7.0-Nightly]
     identifier: tests-8.7to9.0
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
     tf_extra_params:
       environments:
         - tmt:
@@ -180,7 +180,7 @@ jobs:
         distros: [RHEL-8.6.0-Nightly]
     identifier: tests-8.6to9.0-sst
     tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
     tf_extra_params:
       environments:
         - tmt:
@@ -202,7 +202,7 @@ jobs:
         distros: [RHEL-8.6-rhui]
     identifier: tests-8to9-aws-e2e
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
     tf_extra_params:
       environments:
         - tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,7 +55,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.6
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
     tf_extra_params:
       environments:
         - tmt:
@@ -75,7 +75,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.8
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
     tf_extra_params:
       environments:
         - tmt:
@@ -95,7 +95,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.8-sst
     tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
     tf_extra_params:
       environments:
         - tmt:
@@ -115,7 +115,7 @@ jobs:
         distros: [RHEL-7.9-rhui]
     identifier: tests-7to8-aws-e2e
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms; yum install -y \"leapp-upgrade*master*\""
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
     tf_extra_params:
       environments:
         - tmt:
@@ -136,7 +136,7 @@ jobs:
         distros: [RHEL-8.6.0-Nightly]
     identifier: tests-8.6to9.0
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
     tf_extra_params:
       environments:
         - tmt:
@@ -158,7 +158,7 @@ jobs:
         distros: [RHEL-8.7.0-Nightly]
     identifier: tests-8.7to9.0
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
     tf_extra_params:
       environments:
         - tmt:
@@ -180,7 +180,7 @@ jobs:
         distros: [RHEL-8.6.0-Nightly]
     identifier: tests-8.6to9.0-sst
     tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
     tf_extra_params:
       environments:
         - tmt:
@@ -202,7 +202,7 @@ jobs:
         distros: [RHEL-8.6-rhui]
     identifier: tests-8to9-aws-e2e
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\""
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
     tf_extra_params:
       environments:
         - tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,7 +55,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.6
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
     tf_extra_params:
       environments:
         - tmt:
@@ -75,7 +75,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.8
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
     tf_extra_params:
       environments:
         - tmt:
@@ -95,7 +95,7 @@ jobs:
         distros: [RHEL-7.9-ZStream]
     identifier: tests-7.9to8.8-sst
     tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
     tf_extra_params:
       environments:
         - tmt:
@@ -115,7 +115,7 @@ jobs:
         distros: [RHEL-7.9-rhui]
     identifier: tests-7to8-aws-e2e
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-7/group_oamg-leapp-epel-7.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
     tf_extra_params:
       environments:
         - tmt:
@@ -136,7 +136,7 @@ jobs:
         distros: [RHEL-8.6.0-Nightly]
     identifier: tests-8.6to9.0
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
     tf_extra_params:
       environments:
         - tmt:
@@ -158,7 +158,7 @@ jobs:
         distros: [RHEL-8.7.0-Nightly]
     identifier: tests-8.7to9.0
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
     tf_extra_params:
       environments:
         - tmt:
@@ -180,7 +180,7 @@ jobs:
         distros: [RHEL-8.6.0-Nightly]
     identifier: tests-8.6to9.0-sst
     tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
     tf_extra_params:
       environments:
         - tmt:
@@ -202,7 +202,7 @@ jobs:
         distros: [RHEL-8.6-rhui]
     identifier: tests-8to9-aws-e2e
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
-    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+    tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; curl https://copr.fedorainfracloud.org/coprs/g/oamg/leapp/repo/epel-8/group_oamg-leapp-epel-8.repo --output /etc/yum.repos.d/copr_build.repo; yum install -y leapp-repository*master*"
     tf_extra_params:
       environments:
         - tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -54,7 +54,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to84
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
+  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
@@ -66,7 +66,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to84-sst
   tmt_plan: "^(/plans/morf)(?!.*sap)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
+  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
   env: 
     TARGET_RELEASE: 8.6
 
@@ -80,7 +80,7 @@ jobs:
       distros: [RHEL-7.9-rhui]
   identifier: tests-7to8-aws
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms;  yum install -y leapp-repository*master*"
+  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms; yum install -y \"leapp-upgrade*master*\"'
   env: 
     RHUI: "aws"
 
@@ -94,7 +94,7 @@ jobs:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-79to86
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
+  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
   env: 
     TARGET_RELEASE: 8.6
 
@@ -108,7 +108,7 @@ jobs:
       distros: [RHEL-8.6-rhui]
   identifier: tests-8to9-aws
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
+  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
   env:
     RHUI: aws
 
@@ -122,7 +122,7 @@ jobs:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-86to90
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
+  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
   env:
     TARGET_RELEASE: "9.0"
     TARGET_KERNEL: el9
@@ -138,7 +138,7 @@ jobs:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-86to90-sst
   tmt_plan: "^(/plans/morf)(?!.*sap)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
+  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
   env:
     TARGET_RELEASE: "9.0"
     TARGET_KERNEL: el9
@@ -154,7 +154,7 @@ jobs:
       distros: [RHEL-8.7.0-Nightly]
   identifier: tests-87to91
   tmt_plan: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-  tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y leapp-repository*master*"
+  tf_post_install_script: '#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum install -y \"leapp-upgrade*master*\"'
   env:
     LEAPP_DEVEL_TARGET_PRODUCT_TYPE: beta
     RHSM_SKU: RH00069

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -132,7 +132,7 @@ jobs:
     use_internal_tf: True
     trigger: pull_request
     targets:
-      epel-7-x86_64:
+      epel-8-x86_64:
         distros: [RHEL-8.6.0-Nightly]
     identifier: tests-8.6to9.0
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
@@ -154,7 +154,7 @@ jobs:
     use_internal_tf: True
     trigger: pull_request
     targets:
-      epel-7-x86_64:
+      epel-8-x86_64:
         distros: [RHEL-8.7.0-Nightly]
     identifier: tests-8.7to9.0
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*max_sst)"
@@ -176,7 +176,7 @@ jobs:
     use_internal_tf: True
     trigger: pull_request
     targets:
-      epel-7-x86_64:
+      epel-8-x86_64:
         distros: [RHEL-8.6.0-Nightly]
     identifier: tests-8.6to9.0-sst
     tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
@@ -198,7 +198,7 @@ jobs:
     use_internal_tf: True
     trigger: pull_request
     targets:
-      epel-7-x86_64:
+      epel-8-x86_64:
         distros: [RHEL-8.6-rhui]
     identifier: tests-8to9-aws-e2e
     tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"


### PR DESCRIPTION
This pull request introduces the execution of leapp integration tests as a packit job instead of the current behavior of using a GitHub Actions to trigger the tests by a comment.

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>