### PR TITLE
Encode output.print_error message to avoid UnicodeEncodeError when displaying errors

### DIFF
--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 from contextlib import contextmanager
+import six
 
 from leapp.exceptions import LeappRuntimeError
 from leapp.models import ErrorModel
@@ -43,9 +44,14 @@ def pretty_block(text, target, end_text=None, color=Color.bold, width=60):
 
 def print_error(error):
     model = ErrorModel.create(json.loads(error['message']['data']))
+
+    error_message = model.message
+    if six.PY2:
+        error_message = model.message.encode('utf-8', 'xmlcharrefreplace')
+
     sys.stdout.write("{red}{time} [{severity}]{reset} Actor: {actor}\nMessage: {message}\n".format(
         red=Color.red, reset=Color.reset, severity=model.severity.upper(),
-        message=model.message, time=model.time, actor=model.actor))
+        message=error_message, time=model.time, actor=model.actor))
     if model.details:
         print('Summary:')
         details = json.loads(model.details)

--- a/tests/scripts/test_utils_output.py
+++ b/tests/scripts/test_utils_output.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from leapp.utils.output import print_error
+
+
+error = {'message': {'data': ('{"severity": "warning", "time": "2023-12-12T00:00:42", "actor": "An actor",'
+                              '"message": "Нечакана"}')}}
+
+
+def test_print_error_no_unicodedecodeerror():
+    # Make sure no exception is raised
+    print_error(error)


### PR DESCRIPTION
When leapp executes in a Python 2 environment, an actor encountering an error can cause further issues if the message string provided to `leapp.utils.output` contains non-ASCII characters. 

This line in output.py is the main problem:

```python
sys.stdout.write("{red}{time} [{severity}]{reset} Actor: {actor}\nMessage: {message}\n".format(
        red=Color.red, reset=Color.reset, severity=model.severity.upper(),
        message=model.message, time=model.time, actor=model.actor))
```
As you can see, this line isn't Unicode in Python 2, which is why trying to format it with u-strings directly will end up causing an error like the one below:

```
Dec 05 08:19:44 localhost upgrade[437]: Traceback (most recent call last):
Dec 05 08:19:44 localhost upgrade[437]:   File "/usr/bin/leapp", line 9, in <module>
Dec 05 08:19:44 localhost upgrade[437]:     load_entry_point('leapp==0.14.0', 'console_scripts', 'leapp')()
Dec 05 08:19:44 localhost upgrade[437]:   File "/usr/lib/python2.7/site-packages/leapp/cli/__init__.py", line 37, in main
Dec 05 08:19:44 localhost upgrade[437]:     cli.command.execute('leapp version {}'.format(VERSION))
Dec 05 08:19:44 localhost upgrade[437]:   File "/usr/lib/python2.7/site-packages/leapp/utils/clicmd.py", line 106, in execute
Dec 05 08:19:44 localhost upgrade[437]:     args.func(args)
Dec 05 08:19:44 localhost upgrade[437]:   File "/usr/lib/python2.7/site-packages/leapp/utils/clicmd.py", line 128, in called
Dec 05 08:19:44 localhost upgrade[437]:     self.target(args)
Dec 05 08:19:44 localhost upgrade[437]:   File "/usr/lib/python2.7/site-packages/leapp/cli/commands/upgrade/breadcrumbs.py", line 94, in wrapper
Dec 05 08:19:44 localhost upgrade[437]:     return f(*args, breadcrumbs=breadcrumbs, **kwargs)
Dec 05 08:19:44 localhost upgrade[437]:   File "/usr/lib/python2.7/site-packages/leapp/cli/commands/upgrade/__init__.py", line 101, in upgrade
Dec 05 08:19:44 localhost upgrade[437]:     report_errors(workflow.errors)
Dec 05 08:19:44 localhost upgrade[437]:   File "/usr/lib/python2.7/site-packages/leapp/utils/output.py", line 100, in report_errors
Dec 05 08:19:44 localhost upgrade[437]:     print_error(error)
Dec 05 08:19:44 localhost upgrade[437]:   File "/usr/lib/python2.7/site-packages/leapp/utils/output.py", line 48, in print_error
Dec 05 08:19:44 localhost upgrade[437]:     message=model.message, time=model.time, actor=model.actor))
Dec 05 08:19:44 localhost upgrade[437]: UnicodeEncodeError: 'ascii' codec can't encode character u'\u2192' in position 389382: ordinal not in range(128)
Dec 05 08:19:44 localhost upgrade[433]: Container sysroot failed with error code 1.
```

This results in the actor error itself not being displayed, only the subsequent UnicodeEncodeError exception.

I'm not sure the way I went about correcting the problem in this PR is the optimal one.
If there's a different solution you'd rather see, please let me know.