### PR TITLE
change the permissions for /var/lib/leapp directory from '755' to '700'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ install:
 	install -dm 0755 ${CONFDIR}
 	install -m 0744 etc/leapp/leapp.conf ${CONFDIR}
 	install -m 0744 etc/leapp/logger.conf ${CONFDIR}
-	install -dm 0755 ${LIBDIR}
+	install -dm 0700 ${LIBDIR}
 	umask 177 && $(PYTHON_VENV) -c "import sqlite3; sqlite3.connect('${LIBDIR}/audit.db').executescript(open('res/audit-layout.sql', 'r').read())"
 
 install-test:

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -180,7 +180,7 @@ install -m 0644 -p man/snactor.1 %{buildroot}%{_mandir}/man1/
 install -m 0755 -d %{buildroot}%{_datadir}/leapp
 install -m 0755 -d %{buildroot}%{_datadir}/leapp/report_schema
 install -m 0644 -p report-schema-v110.json %{buildroot}%{_datadir}/leapp/report_schema/report-schema.json
-install -m 0755 -d %{buildroot}%{_sharedstatedir}/leapp
+install -m 0700 -d %{buildroot}%{_sharedstatedir}/leapp
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/repos.d
 install -m 0600 -d %{buildroot}%{_sysconfdir}/leapp/answers


### PR DESCRIPTION
The nature of the content stored in the ``/var/lib/leapp`` directory requires stricter permissions.