### PR TITLE
Make copr-build functioning again

### DIFF
--- a/.github/workflows/reuse-copr-build.yml
+++ b/.github/workflows/reuse-copr-build.yml
@@ -66,7 +66,7 @@ jobs:
           cat << EOF > copr_fedora.conf
           [copr-cli]
           login = ${{ secrets.FEDORA_COPR_LOGIN }}
-          username = @oamg
+          username = oamgbot
           token = ${{ secrets.FEDORA_COPR_TOKEN }}
           copr_url = https://copr.fedorainfracloud.org
           # expiration date: 2030-07-04
@@ -79,18 +79,22 @@ jobs:
 
       - name: Trigger copr build
         id: copr_build
+        env:
+          COPR_CONFIG: "copr_fedora.conf"
+          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
+          COPR_REPO: "@oamg/leapp"
         run: |
           cat << EOF > copr_fedora.conf
           [copr-cli]
           login = ${{ secrets.FEDORA_COPR_LOGIN }}
-          username = @oamg
+          username = oamgbot
           token = ${{ secrets.FEDORA_COPR_TOKEN }}
           copr_url = https://copr.fedorainfracloud.org
           # expiration date: 2030-07-04
           EOF
 
           pip install copr-cli
-          PR=${{ steps.pr_nr.outputs.pr_nr }} COPR_CONFIG=copr_fedora.conf make copr_build | tee copr.log
+          PR=${{ steps.pr_nr.outputs.pr_nr }} COPR_CHROOT=$COPR_CHROOT COPR_REPO="$COPR_REPO" COPR_CONFIG=$COPR_CONFIG make copr_build | tee copr.log
 
           COPR_URL=$(grep -Po 'https://copr.fedorainfracloud.org/coprs/build/\d+' copr.log)
           echo "::set-output name=copr_url::${COPR_URL}"
@@ -133,6 +137,10 @@ jobs:
       - name: Trigger copr build for leapp-repository
         id: copr_build_leapp_repository
         if: ${{ steps.leapp_repository_pr_regex_match.outputs.match != '' }}
+        env:
+          COPR_CONFIG: "copr_fedora.conf"
+          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
+          COPR_REPO: "@oamg/leapp"
         run: |
           cat << EOF > copr_fedora.conf
           [copr-cli]
@@ -144,7 +152,7 @@ jobs:
           EOF
 
           pip install copr-cli
-          PR=${{ steps.leapp_repository_pr.outputs.leapp_repository_pr }} COPR_CONFIG=copr_fedora.conf make copr_build | tee copr.log
+          PR=${{ steps.leapp_repository_pr.outputs.leapp_repository_pr }} COPR_CHROOT=COPR_CHROOT COPR_REPO="$COPR_REPO" COPR_CONFIG=$COPR_CONFIG make copr_build | tee copr.log
 
           COPR_URL=$(grep -Po 'https://copr.fedorainfracloud.org/coprs/build/\d+' copr.log)
           echo "::set-output name=copr_url::${COPR_URL}"


### PR DESCRIPTION
After some unknown changes around COPR, the building
command and the used COPR configuration file needs to be
updated.


OAMG-8876