### PR TITLE
Do not set COPR_CHROOTS for copr-build

### DIFF
--- a/.github/workflows/reuse-copr-build.yml
+++ b/.github/workflows/reuse-copr-build.yml
@@ -81,7 +81,6 @@ jobs:
         id: copr_build
         env:
           COPR_CONFIG: "copr_fedora.conf"
-          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
           COPR_REPO: "@oamg/leapp"
         run: |
           cat << EOF > copr_fedora.conf
@@ -94,7 +93,7 @@ jobs:
           EOF
 
           pip install copr-cli
-          PR=${{ steps.pr_nr.outputs.pr_nr }} COPR_CHROOT=$COPR_CHROOT COPR_REPO="$COPR_REPO" COPR_CONFIG=$COPR_CONFIG make copr_build | tee copr.log
+          PR=${{ steps.pr_nr.outputs.pr_nr }} COPR_REPO="$COPR_REPO" COPR_CONFIG=$COPR_CONFIG make copr_build | tee copr.log
 
           COPR_URL=$(grep -Po 'https://copr.fedorainfracloud.org/coprs/build/\d+' copr.log)
           echo "::set-output name=copr_url::${COPR_URL}"
@@ -139,7 +138,6 @@ jobs:
         if: ${{ steps.leapp_repository_pr_regex_match.outputs.match != '' }}
         env:
           COPR_CONFIG: "copr_fedora.conf"
-          COPR_CHROOT: "epel-7-x86_64,epel-8-x86_64"
           COPR_REPO: "@oamg/leapp"
         run: |
           cat << EOF > copr_fedora.conf
@@ -152,7 +150,7 @@ jobs:
           EOF
 
           pip install copr-cli
-          PR=${{ steps.leapp_repository_pr.outputs.leapp_repository_pr }} COPR_CHROOT=COPR_CHROOT COPR_REPO="$COPR_REPO" COPR_CONFIG=$COPR_CONFIG make copr_build | tee copr.log
+          PR=${{ steps.leapp_repository_pr.outputs.leapp_repository_pr }} COPR_REPO="$COPR_REPO" COPR_CONFIG=$COPR_CONFIG make copr_build | tee copr.log
 
           COPR_URL=$(grep -Po 'https://copr.fedorainfracloud.org/coprs/build/\d+' copr.log)
           echo "::set-output name=copr_url::${COPR_URL}"


### PR DESCRIPTION
Previous patch follow up: in case of leapp this
should not be specified.

OAMG-8876