### PR TITLE
Make copr-build for /rerun 42 functional again

### DIFF
--- a/.github/workflows/reuse-copr-build.yml
+++ b/.github/workflows/reuse-copr-build.yml
@@ -143,7 +143,7 @@ jobs:
           cat << EOF > copr_fedora.conf
           [copr-cli]
           login = ${{ secrets.FEDORA_COPR_LOGIN }}
-          username = @oamg
+          username = oamgbot
           token = ${{ secrets.FEDORA_COPR_TOKEN }}
           copr_url = https://copr.fedorainfracloud.org
           # expiration date: 2030-07-04


### PR DESCRIPTION
copr config username for a dependent leapp-repository PR build case wasn't changed in the 5ddce5a. This patch should address that.

OAMG-8876