### PR TITLE
Save actor tracebacks in leapp.db

### DIFF
--- a/leapp/messaging/__init__.py
+++ b/leapp/messaging/__init__.py
@@ -147,8 +147,8 @@ class BaseMessaging(object):
         self._do_produce(model, actor, self._errors)
 
     def report_stacktrace(self, message, trace, actorname):
-        model = ErrorModel(message="{message}\n{trace}".format(message=message, trace=trace),
-                           actor=actorname, severity="fatal", time=datetime.datetime.now())
+        model = ErrorModel(message=message, details=trace, actor=actorname, severity="fatal",
+                           time=datetime.datetime.now())
         self._do_produce(model, actorname, self._errors)
 
     def request_stop_after_phase(self):

--- a/leapp/messaging/__init__.py
+++ b/leapp/messaging/__init__.py
@@ -146,6 +146,11 @@ class BaseMessaging(object):
                            time=datetime.datetime.now())
         self._do_produce(model, actor, self._errors)
 
+    def report_stacktrace(self, message, trace, actorname):
+        model = ErrorModel(message="{message}\n{trace}".format(message=message, trace=trace),
+                           actor=actorname, severity="fatal", time=datetime.datetime.now())
+        self._do_produce(model, actorname, self._errors)
+
     def request_stop_after_phase(self):
         """
         If called, it will cause the workflow to stop the execution after the current phase ends.
@@ -222,7 +227,7 @@ class BaseMessaging(object):
         data = json.dumps(model.dump(), sort_keys=True)
         message = {
             'type': type(model).__name__,
-            'actor': type(actor).name,
+            'actor': type(actor).name if not isinstance(actor, str) else actor,
             'topic': model.topic.name,
             'stamp': datetime.datetime.utcnow().isoformat() + 'Z',
             'phase': os.environ.get('LEAPP_CURRENT_PHASE', 'NON-WORKFLOW-EXECUTION'),

--- a/leapp/workflows/__init__.py
+++ b/leapp/workflows/__init__.py
@@ -340,7 +340,11 @@ class Workflow(with_metaclass(WorkflowMeta)):
                         instance.run()
                     except BaseException as exc:
                         self._unhandled_exception = True
-                        messaging.report_stacktrace(message=exc.message, trace=exc.exception_info, actorname=actor.name)
+                        messaging.report_stacktrace(message=exc.message,
+                                                    trace=exc.exception_info,
+                                                    actorname=actor.name)
+                        current_logger.error('Actor {actor} has crashed: {trace}'.format(actor=actor.name,
+                                                                                         trace=exc.exception_info))
                         raise
 
                     self._stop_after_phase_requested = messaging.stop_after_phase or self._stop_after_phase_requested

--- a/leapp/workflows/__init__.py
+++ b/leapp/workflows/__init__.py
@@ -338,8 +338,9 @@ class Workflow(with_metaclass(WorkflowMeta)):
                                      config_model=config_model, skip_dialogs=skip_dialogs)
                     try:
                         instance.run()
-                    except BaseException:
+                    except BaseException as exc:
                         self._unhandled_exception = True
+                        messaging.report_stacktrace(message=exc.message, trace=exc.exception_info, actorname=actor.name)
                         raise
 
                     self._stop_after_phase_requested = messaging.stop_after_phase or self._stop_after_phase_requested


### PR DESCRIPTION
Now when an exception is thrown during actor
execution it won't be shown only on stdout, but
will appear in leapp.db and leapp report as high
risk report message.

OAMG-4186