### PR TITLE
Fix invalid type check

### DIFF
--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -107,7 +107,7 @@ def report_errors(errors):
 
 def report_info(report_paths, log_paths, answerfile=None, fail=False):
     report_paths = [report_paths] if not isinstance(report_paths, list) else report_paths
-    log_paths = [log_paths] if not isinstance(report_paths, list) else log_paths
+    log_paths = [log_paths] if not isinstance(log_paths, list) else log_paths
 
     if log_paths:
         sys.stdout.write("\n")


### PR DESCRIPTION
The `isinstance` type check in `report_info` checks the type of an incorrect variable. This fixes the issue.