### PR TITLE
stdlib.run: Fix missing executable

### DIFF
--- a/tests/scripts/test_stdlib_call_audit.py
+++ b/tests/scripts/test_stdlib_call_audit.py
@@ -1,7 +1,18 @@
+import os
 import pytest
 import six
 
 from leapp.libraries.stdlib import run
+
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture
+def adjust_cwd():
+    previous_cwd = os.getcwd()
+    os.chdir(os.path.join(CUR_DIR, "../"))
+    yield
+    os.chdir(previous_cwd)
 
 
 def test_invalid_command():
@@ -35,3 +46,24 @@ def test_no_encoding():
     cmd = ['echo', '-n', '-e', '\\xeb']
     result = run(cmd, encoding=None)
     assert isinstance(result['stdout'], six.binary_type)
+
+
+def test_missing_executable(monkeypatch, adjust_cwd):  # no-qa: W0613; pylint: disable=unused-argument
+    """
+    In case the executable is missing.
+
+    :return: Pass/Fail
+    """
+    def mocked_fork():
+        # raise the generic exception as we want to prevent fork in this case
+        # and want to bypass possible catch
+        raise Exception()  # no-qa: W0719; pylint: disable=broad-exception-raised
+
+    monkeypatch.setattr(os, 'fork', mocked_fork)
+    with pytest.raises(OSError):
+        run(['my-non-existing-exec-2023-asdf'])
+
+    with pytest.raises(OSError):
+        # this file is not executable, so even if it exists the OSError should
+        # be still raised
+        run(['panagrams'], env={'PATH': '../data/call_data/'})

--- a/tests/scripts/test_utils_project.py
+++ b/tests/scripts/test_utils_project.py
@@ -5,13 +5,13 @@ import pytest
 from helpers import TESTING_REPOSITORY_NAME
 from leapp.exceptions import CommandError
 from leapp.utils.repository import (
-    requires_repository,
-    to_snake_case,
+    find_repository_basedir,
+    get_repository_metadata,
+    get_repository_name,
     make_class_name,
     make_name,
-    find_repository_basedir,
-    get_repository_name,
-    get_repository_metadata,
+    requires_repository,
+    to_snake_case,
 )
 
 


### PR DESCRIPTION
Currently, if the executable required in `run` does not exist (or is not executable), the child process's code is not replaced by `os.execvpe` function and it raises the OSError instead. However, the parent process does not get this OSError. It consumes exit code, stderr, ... of the child process. So in case the code does something like this:

    ```
    try:
        result = run(['non-executable'])
    except OSError:
        pass
    except CalledProcessError:
        # do something..
    ```

the child process passes and do whatever.. In case it ends with zero exit code, the obtained result is usually something totally different than expected in actors. Also there could be problems with non-idempotent code, when some actions could be done twice (once executed by the child, send time executed by the parent [current] process).

We have realized that number of existing leapp actors for in-place upgrades already count with the raise of OSError when executable cannot be used. So we choosed for now to check whether executables are present and raise OSError if not, so we are sure that only one process leave the function really.

Also applied another seatbelt into the child process - if the OSError is raised anyway despite our checks (e.g. SELinux prevents the execution) let's just kill the process instead giving it a possibility to continue. In such a case, always print a msg to stderr of the child process and exit with ecode 1.

**Note**: To check an executable we use `distutils.spawn.find_executable` which is deprecated in Python 3 and will be dropped in Python 3.12. However it exists now for Python 2 & 3, so we use this one for now and will replace it in future by `shutils.which` when the time comes.

## Additional changes:
* Make pylint happy (set noqa for E721 for the check the Fields is not
created directly). The "isinstance" function has a different behaviour
in this case than we want.

* Fix imports to make pylint happy

* Set `result` to empty dict instead of None: in case a ValueError
  or TypeError is raised inside the _call function, it's expected
  to copy the `result` content inside the final block, however in
  case the results is None, it fails and raise additional exception
  that covers the original one.

* Update unit tests to cover issues with missing executable


## Missing:
- [x] update unit-tests