### PR TITLE
Add an ERROR report group

### DIFF
--- a/leapp/models/fields/__init__.py
+++ b/leapp/models/fields/__init__.py
@@ -46,7 +46,7 @@ class Field(object):
         self._nullable = False
         self._default = default
 
-        if type(self) == Field:
+        if type(self) is Field:
             raise ModelMisuseError("Do not use this type directly.")
 
     def _validate_model_value(self, value, name):

--- a/tests/scripts/test_utils_project.py
+++ b/tests/scripts/test_utils_project.py
@@ -4,8 +4,15 @@ import pytest
 
 from helpers import TESTING_REPOSITORY_NAME
 from leapp.exceptions import CommandError
-from leapp.utils.repository import requires_repository, to_snake_case, make_class_name, make_name,\
-    find_repository_basedir, get_repository_name, get_repository_metadata
+from leapp.utils.repository import (
+    requires_repository,
+    to_snake_case,
+    make_class_name,
+    make_name,
+    find_repository_basedir,
+    get_repository_name,
+    get_repository_metadata,
+)
 
 
 def setup_module():


### PR DESCRIPTION
Currently there is no straightforward way to identify whether a report is an ordinary report or an error report (report generated from an error).

An `ERROR` group is introduced in `leapp.reporting.Groups.ERROR` which is used to group error reports. This is utilized in the leapp output to show the number of error reports in the summary. Also error reports in `leapp-report.txt` are now followed by a "(error)" string similar to inhibitors.

Jira: OAMG-9532