### PR TITLE
Release 0.16.0

### DIFF
--- a/docs/source/el7toel8/deprecation.md
+++ b/docs/source/el7toel8/deprecation.md
@@ -14,6 +14,15 @@ framework, see [List of deprecated functionality in leapp](../deprecation.html#l
 
 - nothing yet...
 
+## v0.19.0 <span style="font-size:0.5em; font-weight:normal">(till March 2024)</span>
+
+- Models
+  - **InstalledTargetKernelVersion** - Deprecated as the new solution has been designed to be able to handle new changes in RHEL 9.3+ system. Use the `InstalledTargetKernelInfo` message instead.
+  - **GrubInfo.orig_device_name** - The `GrubInfo` message is still valid, but the `orig_device_name` field has been deprecated as multiple devices can exist on a system. Use `GrubInfo.orig_devices` instead.
+- Shared libraries
+  - **leapp.libraries.common.config.version.is_rhel_realtime()** - The function has been deprecated as the information cannot be easily determined based on the information inside `IPUConfig`. Use data in the `KernelInfo` message instead, the field `type`.
+  - **leapp.libraries.common.grub.get_grub_device()** - The function has been deprecated as multiple grub devices can exists on a system. Use the `leapp.libraries.common.grub.get_grub_devices()` function instead.
+
 ## v0.16.0 <span style="font-size:0.5em; font-weight:normal">(till September 2022)</span>
 
 - Shared libraries

--- a/docs/source/el7toel8/envars.md
+++ b/docs/source/el7toel8/envars.md
@@ -188,3 +188,7 @@ on the system. Currently it works only for the most simple configurations
 storage is not handled anyhow during the upgrade, so it's possible that the network
 based storage will not be correctly initialized and usable as expected).
 
+## LEAPP_DEVEL_KEEP_DISK_IMGS
+If set to 1, leapp will skip removal of disk images created for source OVLs.
+This is handy for debugging and investigations related to created containers
+(the scratch one and the target userspace container).

--- a/leapp/__init__.py
+++ b/leapp/__init__.py
@@ -1,6 +1,6 @@
 from leapp.utils.workarounds import apply_workarounds
 
-VERSION = "0.15.1"
+VERSION = "0.16.0"
 FULL_VERSION = VERSION
 
 apply_workarounds()

--- a/man/leapp.1
+++ b/man/leapp.1
@@ -1,4 +1,4 @@
-.TH LEAPP "1" "2023-02-21" "leapp 0.15.1" "User Commands"
+.TH LEAPP "1" "2023-08-23" "leapp 0.16.0" "User Commands"
 
 .SH NAME
 leapp \- command line interface for upgrades between major OS versions

--- a/man/snactor.1
+++ b/man/snactor.1
@@ -1,4 +1,4 @@
-.TH SNACTOR "1" "2023-02-21" "snactor 0.15.1" "User Commands"
+.TH SNACTOR "1" "2023-08-23" "snactor 0.16.0" "User Commands"
 
 .SH NAME
 snactor \- development and repository management tool for leapp

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -42,7 +42,7 @@
 %endif
 
 Name:       leapp
-Version:    0.15.1
+Version:    0.16.0
 Release:    1%{?dist}
 Summary:    OS & Application modernization framework
 


### PR DESCRIPTION
Release 0.16.0

## Packaging
-  Provide leapp-framework 5.0 (#818, #840)

## Framework
### Fixes
- Improve processing of reports with UTF-8 characters (#821, #828)
- Fix info reporting with only one path to log (#834)

### Enhancements
- Include tracebacks of actors into the leapp.db (#832)


## Leapp (tool)
### Fixes
- Dialog creation fails not more for a component without choices (#826)
- Empty report is generated correctly (#828)
- Fix processing data in remediation instructions with non-ascii characters ()

### Enhancements
- Improve report summary output to make it more visible (#818, #840)


## stdlib
### Fixes
- Fixed the call when the execute cannot be performed (#836)
### Enhancements
- changes related just to stdlib - under leapp/libraries/stdlib


## Additional changes (unrelated ro leapp release)
- update the deprecation list for the leapp-repository 0.19.0
- update the list of envars