### PR TITLE
Add process locking

### DIFF
--- a/leapp/config.py
+++ b/leapp/config.py
@@ -40,6 +40,9 @@ _CONFIG_DEFAULTS = {
         'dir': '/var/log/leapp/',
         'files': ','.join(_FILES_TO_ARCHIVE),
     },
+    'lock': {
+        'path': '/var/run/leapp.pid'
+    },
     'logs': {
         'dir': '/var/log/leapp/',
         'files': ','.join(_LOGS),

--- a/leapp/exceptions.py
+++ b/leapp/exceptions.py
@@ -148,3 +148,7 @@ class RequestStopAfterPhase(LeappError):
 
     def __init__(self):
         super(RequestStopAfterPhase, self).__init__('Stop after phase has been requested.')
+
+
+class ProcessLockError(LeappError):
+    """ This exception is used to represent an error within the process locking mechanism. """

--- a/leapp/utils/lock.py
+++ b/leapp/utils/lock.py
@@ -1,0 +1,83 @@
+import os
+import fcntl
+import logging
+
+from leapp.config import get_config
+from leapp.exceptions import ProcessLockError
+
+
+def leapp_lock(lockfile=None):
+    return ProcessLock(lockfile=lockfile)
+
+
+def _acquire_lock(fd):
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError:
+        return False
+
+
+def _clear_lock(fd):
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.ftruncate(fd, 0)
+
+
+def _read_pid(fd):
+    return os.read(fd, 20)
+
+
+def _write_pid(fd, pid):
+    _clear_lock(fd)
+    os.write(fd, str(pid).encode('utf-8'))
+
+
+class ProcessLock(object):
+
+    def __init__(self, lockfile=None):
+        self.log = logging.getLogger('leapp.utils.lock')
+        self.lockfile = lockfile if lockfile else get_config().get('lock', 'path')
+
+        self.fd = None
+
+    def _get_pid_from_lockfile(self):
+        running_pid = _read_pid(self.fd)
+        self.log.debug("_get_pid_from_lockfile: running_pid=%s", running_pid)
+        running_pid = int(running_pid)
+
+        return running_pid
+
+    def _try_lock(self, pid):
+        if not _acquire_lock(self.fd):
+            try:
+                running_pid = self._get_pid_from_lockfile()
+            except ValueError:
+                process_msg = ''
+            else:
+                process_msg = ' by process with PID {}'.format(running_pid)
+
+            msg = (
+                'Leapp is currently locked{} and cannot be started.\n'
+                'Please ensure no other instance of leapp is running and then delete the lockfile at {} and try again.'
+            ).format(process_msg, self.lockfile)
+            raise ProcessLockError(msg)
+
+        try:
+            _write_pid(self.fd, pid)
+        except OSError:
+            raise ProcessLockError('Could not write PID to lockfile.')
+
+    def __enter__(self):
+        my_pid = os.getpid()
+
+        self.fd = os.open(self.lockfile, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            self._try_lock(my_pid)
+        except ProcessLockError:
+            os.close(self.fd)
+            raise
+
+    def __exit__(self, *exc_args):
+        _clear_lock(self.fd)
+        os.close(self.fd)
+        os.unlink(self.lockfile)


### PR DESCRIPTION
This change addresses the potential risk of running multiple instances of Leapp simultaneously on a single system. 

Considerations:
- Insights Tasks (preupgrade and upgrade) currently allow multiple executions on the same system
- The absence of a filter/tooltip in the Insights user interface makes it challenging to determine if a task is already running on a system.

A simple lock mechanism to prevent concurrent executions using a BSD lock has been implemented (see [1](http://gavv.net/articles/file-locks/#bsd-locks-flock)).

JIRA: https://issues.redhat.com/browse/OAMG-9827