### PR TITLE
Enable building for EL 9 and support Python 3.12

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,8 +16,9 @@ jobs:
       matrix:
         scenarios:
           - name: Run unit tests with python3.9 on el8
+          - name: Run unit tests with python3.9 on el9
             python: python3.9
-            container: ubi8
+            container: ubi9
           - name: Run unit tests with python 3.6 on el8
             python: python3.6
             container: ubi8

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         scenarios:
-          - name: Run unit tests with python3.9 on el8
+          - name: Run unit tests with python3.12 on el9
+            python: python3.12
+            container: ubi10
           - name: Run unit tests with python3.9 on el9
             python: python3.9
             container: ubi9

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,7 @@ jobs:
     targets:
     - epel-7-x86_64
     - epel-8-x86_64
+    - epel-9-x86_64
     - fedora-all-aarch64
     - fedora-all-x86_64
   actions:
@@ -32,6 +33,7 @@ jobs:
     targets:
     - epel-7-x86_64
     - epel-8-x86_64
+    - epel-9-x86_64
     - fedora-all-aarch64
     - fedora-all-x86_64
   actions:

--- a/leapp/cli/__init__.py
+++ b/leapp/cli/__init__.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 import pkgutil
 import socket
@@ -24,7 +25,11 @@ def _load_commands(base_command):
         if os.path.isdir(entry_path) and os.path.isfile(os.path.join(entry_path, '__init__.py')):
             # We found a package - We will import it and get the `register` symbol and check if it is callable.
             package_name = 'leapp.cli.commands.{}'.format(entry)
-            package = pkgutil.get_loader(package_name).load_module(package_name)
+            if sys.version_info < (3, 12):
+                # get_loader and load_module are deprecated since 3.12
+                package = pkgutil.get_loader(package_name).load_module(package_name)  # noqa: E501, pylint: disable=deprecated-method
+            else:
+                package = importlib.import_module(package_name)
             register = getattr(package, 'register', None)
             if callable(register):
                 register(base_command)

--- a/leapp/compat.py
+++ b/leapp/compat.py
@@ -1,4 +1,5 @@
 import gettext  # noqa: F401; pylint: disable=unused-import
+import importlib
 import locale
 import sys
 
@@ -66,3 +67,21 @@ else:
         :return: Nothing
         """
         raise exc.with_traceback(tb)
+
+
+def load_module(importer, name):
+    """
+    Loads a module using the given importer and module name
+
+    :param importer: A finder implementation (returned by e.g. pkgutils.iter_modules)
+    :param name: Module name
+    :return: The loaded module
+    """
+    if sys.version_info < (3, 4):
+        return importer.find_module(name).load_module(name)
+
+    spec = importer.find_spec(name)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/leapp/libraries/stdlib/call.py
+++ b/leapp/libraries/stdlib/call.py
@@ -11,7 +11,7 @@ except ImportError:
     # (pstodulk): find_executable() is from the distutils module which was
     # removed in Python 3.12. We can get rid of this fallback when we drop
     # support for Python 2. https://peps.python.org/pep-0632/
-    from distutils.spawn import find_executable as which
+    from distutils.spawn import find_executable as which  # pylint: disable=deprecated-module
 
 from leapp.compat import string_types
 from leapp.libraries.stdlib.eventloop import POLL_HUP, POLL_IN, POLL_OUT, POLL_PRI, EventLoop

--- a/leapp/messaging/answerstore.py
+++ b/leapp/messaging/answerstore.py
@@ -2,6 +2,10 @@ import multiprocessing
 
 import six
 from six.moves import configparser
+try:
+    from six.moves.configparser import SafeConfigParser as ConfigParser
+except ImportError:
+    from six.moves.configparser import ConfigParser
 
 from leapp.exceptions import CommandError
 from leapp.utils.audit import create_audit_entry
@@ -46,10 +50,11 @@ class AnswerStore(object):
         Loads an ini config file from the given location.
 
         :param inifile: Path to the answer file to load.
-        :return: configparser.SafeConfigParser object
+        :return: configparser.ConfigParser object
         :raises CommandError if any of the values are not in key=value format
         """
-        conf = configparser.SafeConfigParser(allow_no_value=False)
+        conf = ConfigParser(allow_no_value=False)
+
         try:
             conf.read(inifile)
             return conf

--- a/leapp/repository/__init__.py
+++ b/leapp/repository/__init__.py
@@ -3,6 +3,7 @@ import os
 import pkgutil
 import sys
 
+from leapp.compat import load_module
 from leapp.exceptions import RepoItemPathDoesNotExistError, UnsupportedDefinitionKindError
 from leapp.models import get_models, resolve_model_references
 import leapp.libraries.common  # noqa # pylint: disable=unused-import
@@ -166,7 +167,7 @@ class Repository(object):
         directories = [os.path.join(self._repo_dir, os.path.dirname(module)) for module in modules]
         prefix = prefix + '.' if not prefix.endswith('.') else prefix
         for importer, name, ispkg in pkgutil.iter_modules(directories, prefix=prefix):
-            importer.find_module(name).load_module(name)
+            load_module(importer, name)
 
     def serialize(self):
         """

--- a/leapp/repository/actor_definition.py
+++ b/leapp/repository/actor_definition.py
@@ -11,6 +11,7 @@ from multiprocessing import Process, Queue, Pipe
 
 import leapp.libraries.actor  # noqa # pylint: disable=unused-import
 from leapp.actors import get_actor_metadata, get_actors
+from leapp.compat import load_module
 from leapp.exceptions import (ActorInspectionFailedError, LeappRuntimeError, MultipleActorsError,
                               UnsupportedDefinitionKindError)
 from leapp.repository.definition import DefinitionKind
@@ -193,7 +194,7 @@ class ActorDefinition(object):
                 path = os.path.abspath(os.path.join(self._repo_dir, self.directory))
                 for importer, name, is_pkg in pkgutil.iter_modules((path,)):
                     if not is_pkg:
-                        self._module = importer.find_module(name).load_module(name)
+                        self._module = load_module(importer, name)
                         break
 
     def discover(self):

--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -2,6 +2,7 @@ import os
 import pkgutil
 import socket
 
+from leapp.compat import load_module
 from leapp.utils.i18n import _  # noqa; pylint: disable=redefined-builtin
 from leapp.snactor import commands
 from leapp.snactor.commands import workflow
@@ -30,7 +31,7 @@ def _load_commands_from(path):
     for importer, name, is_pkg in pkgutil.iter_modules([pkg_path]):
         if is_pkg:
             continue
-        mod = importer.find_module(name).load_module(name)
+        mod = load_module(importer, name)
         if hasattr(mod.cli, 'command'):
             if not mod.cli.command.parent:
                 cli.command.add_sub(mod.cli.command)

--- a/res/container-builds/Containerfile.ubi9
+++ b/res/container-builds/Containerfile.ubi9
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi9/ubi:latest
+
+VOLUME /payload
+
+ENV DIST_VERSION 9
+
+RUN dnf update -y && \
+    dnf install -y python3 make git rpm-build python3-devel
+    #yum install -y python3-pip && \ python3 -m pip install --upgrade pip==20.3.4
+
+WORKDIR /payload
+ENTRYPOINT make build

--- a/res/container-tests/Containerfile.ubi10
+++ b/res/container-tests/Containerfile.ubi10
@@ -14,6 +14,9 @@ ENTRYPOINT virtualenv testenv -p "/usr/bin/$PYTHON_VENV" && \
     pip install -U setuptools && \
     pip install -U funcsigs && \
     pip install -U -r requirements-tests.txt && \
+    # NOTE(mmatuska): The pytest ver defined in requirements-tests is too old \
+    # for Python 3.12 (missing imp module), there do an update here until we \
+    # bump that. Similarly for six. \
     pip install -U pytest && \
     pip install -U six && \
     pip install -U . && \

--- a/res/container-tests/Containerfile.ubi10
+++ b/res/container-tests/Containerfile.ubi10
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/ubi:latest
 VOLUME /payload
 
 RUN dnf update -y && \
-    dnf install python3 python39 make python3-pip -y && \
+    dnf install python3 python312 python3-pip make -y && \
     python3 -m pip install --upgrade pip==20.3.4
 
 RUN pip install virtualenv
@@ -14,6 +14,8 @@ ENTRYPOINT virtualenv testenv -p "/usr/bin/$PYTHON_VENV" && \
     pip install -U setuptools && \
     pip install -U funcsigs && \
     pip install -U -r requirements-tests.txt && \
+    pip install -U pytest && \
+    pip install -U six && \
     pip install -U . && \
     export LINTABLES=$(find . -name '*.py' | grep -E -e '^\./leapp\/' -e '^\./tests/scripts/' | sort -u ) && \
     echo '==================================================' && \

--- a/tests/scripts/test_audit.py
+++ b/tests/scripts/test_audit.py
@@ -4,6 +4,8 @@ import os
 import sqlite3
 import uuid
 
+import pytest
+
 from leapp.utils.audit import get_connection, Execution, Host, MessageData, \
     DataSource, Message, Audit, get_messages, checkpoint, get_checkpoints, create_audit_entry, get_audit_entry
 from leapp.config import get_config
@@ -95,8 +97,12 @@ def setup_module():
     get_config().set('database', 'path', '/tmp/leapp-test.db')
 
 
+@pytest.fixture(autouse=True)
 def setup():
     path = get_config().get('database', 'path')
+    if os.path.isfile(path):
+        os.unlink(path)
+    yield
     if os.path.isfile(path):
         os.unlink(path)
 

--- a/tests/scripts/test_exit_status.py
+++ b/tests/scripts/test_exit_status.py
@@ -29,8 +29,12 @@ def setup_module():
     get_config().set('database', 'path', '/tmp/leapp-test.db')
 
 
+@pytest.fixture(autouse=True)
 def setup():
     path = get_config().get('database', 'path')
+    if os.path.isfile(path):
+        os.unlink(path)
+    yield
     if os.path.isfile(path):
         os.unlink(path)
 


### PR DESCRIPTION
This patch enables building on EL9 along with the testing infrastructure and dev environment prepared for EL9 and EL10.

Included changes:
- Enable EL9 builds in packit
- Add build container for EL9
- Add test container for EL10
- Add tests on Python 3.12 on ubi10 (really it's ubi9) unit test GH action
- Update Makefile to include the new containers
- Handle deprecations in Python 3.12