### PR TITLE
Update packit config after tier redefinition

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -73,7 +73,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & enabled:true'
+        plan_filter: 'tag:tier0 & enabled:true'
     environments:
       - artifacts:
         - type: "repository"
@@ -309,7 +309,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
+        plan_filter: 'tag:tier0 & tag:8to9 & enabled:true'
     environments:
       - artifacts:
         - type: "repository"
@@ -418,7 +418,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
+        plan_filter: 'tag:tier0 & tag:8to9 & enabled:true'
     environments:
       - artifacts:
         - type: "repository"


### PR DESCRIPTION
Now for basic sanity test verification in upstream tests tagged by 'tier0' will be used instead of 'sanity'.

RHELMISC-3211