### PR TITLE
Reword the report msg in the console output to note remediations

### DIFF
--- a/leapp/utils/output.py
+++ b/leapp/utils/output.py
@@ -202,10 +202,12 @@ def report_info(context_id, report_paths, log_paths, answerfile=None, fail=False
             _print_reports_summary(reports)
 
             print(
-                '\n{bold}Before continuing consult the full report:{reset}'
+                '\n{bold}Before continuing, review the full report below for details'
+                ' about discovered problems and possible remediation instructions:{reset}'
                 .format(bold=Color.bold, reset=Color.reset)
             )
-            for report_path in report_paths:
+            for report_path in sorted(report_paths, reverse=True):
+                # NOTE: sort hack -> print .txt first
                 sys.stdout.write("    A report has been generated at {path}\n".format(path=report_path))
 
     if answerfile:


### PR DESCRIPTION
Users who do not understand why they should read the generated leapp report. They are missing that the console output is just a summary overview of the report itself.

Rewording the msg little bit to make it explicitely clear that report contains more details about discovered problems and possible remediation instructions.

Also reverted order of the report about generated report files, making `.txt` version first.

Jira: RHEL-25406, RHEL-25407

### TODO:
* [x] wait for CEE confirmation

### Output
```

============================================================
                      REPORT OVERVIEW                       
============================================================

Upgrade has been inhibited due to the following problems:
    1. Found GRUB devices with too little space reserved before the first partition
    2. Leapp detected loaded kernel drivers which have been removed in RHEL 8. Upgrade cannot proceed.
    3. Possible problems with remote login using root account
    4. Btrfs has been removed from RHEL8
    5. Missing required answers in the answer file

HIGH and MEDIUM severity reports:
    1. Packages available in excluded repositories will not be installed
    2. Packages not signed by Red Hat found on the system
    3. GRUB2 core will be automatically updated during the upgrade
    4. Difference in Python versions and support in RHEL 8

Reports summary:
    Errors:                      0
    Inhibitors:                  5
    HIGH severity reports:       4
    MEDIUM severity reports:     0
    LOW severity reports:        4
    INFO severity reports:       4

Before continuing, review the full report below for details about discovered problems and possible remediation instructions:
    A report has been generated at /var/log/leapp/leapp-report.txt
    A report has been generated at /var/log/leapp/leapp-report.json

============================================================
                   END OF REPORT OVERVIEW                   
============================================================

```