### PR TITLE
snactor: Fix load_module missing in Python 3.12

### DIFF
--- a/leapp/snactor/__init__.py
+++ b/leapp/snactor/__init__.py
@@ -1,6 +1,8 @@
+import importlib
 import os
 import pkgutil
 import socket
+import sys
 
 from leapp.utils.i18n import _  # noqa; pylint: disable=redefined-builtin
 from leapp.snactor import commands
@@ -30,7 +32,11 @@ def _load_commands_from(path):
     for importer, name, is_pkg in pkgutil.iter_modules([pkg_path]):
         if is_pkg:
             continue
-        mod = importer.find_module(name).load_module(name)
+        spec = importer.find_spec(name)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
+
         if hasattr(mod.cli, 'command'):
             if not mod.cli.command.parent:
                 cli.command.add_sub(mod.cli.command)


### PR DESCRIPTION
The solution is taken from #855.