### PR TITLE
Packit: drop epel-7-ppc64le chroot

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,7 +12,6 @@ jobs:
     owner: "@oamg"
     project: leapp
     targets:
-    - epel-7-ppc64le
     - epel-7-x86_64
     - epel-8-x86_64
     - fedora-all-aarch64
@@ -31,7 +30,6 @@ jobs:
     owner: "@oamg"
     project: leapp
     targets:
-    - epel-7-ppc64le
     - epel-7-x86_64
     - epel-8-x86_64
     - fedora-all-aarch64


### PR DESCRIPTION
CentOS 7 is EOM and based on that additional changes have to be made in COPR. Use x86_64 arch for epel7 now only.