### PR TITLE
snactor(run): allow using leapp's execution contexts

### DIFF
--- a/leapp/snactor/context.py
+++ b/leapp/snactor/context.py
@@ -28,6 +28,8 @@ def last_snactor_context(connection=None):
 def with_snactor_context(f):
     @command_aware_wraps(f)
     def wrapper(*args, **kwargs):
-        os.environ["LEAPP_EXECUTION_ID"] = last_snactor_context()
+        # To preserve context, one needs to LEAPP_DEBUG_PRESERVE_CONTEXT=1 and have LEAPP_EXECUTION_ID=<id> set.
+        if not (os.environ.get('LEAPP_DEBUG_PRESERVE_CONTEXT', '0') == '1' and os.environ.get('LEAPP_EXECUTION_ID')):
+            os.environ["LEAPP_EXECUTION_ID"] = last_snactor_context()
         return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
Introduce the `LEAPP_DEBUG_PRESERVE_CONTEXT` environmental variable. When the variable is set to 1 and the environment has `LEAPP_EXECUTION_ID` set, the `LEAPP_EXECUTION_ID` is not overwritten with snactor's execution ID. This allows the developer to run actors in the same fashion as if the actor was run during the last leapp's execution, thus, avoiding to rerun the entire upgrade process. This, naturally, does not help when the actor has outside dependencies, i.e., it requires the filesystem to be set up in a specific way (e.g. a target container) must be present, e.t.c.

Usage:
1. run `leapp upgrade`
2. if you observe your actor crashing, run `leapp-inspector executions` and pick the latest execution ID
3. do `export LEAPP_DEBUG_PRESERVE_CONTEXT=1 LEAPP_EXECUTION_ID=<id>` where `<id>` is the ID of the last exection (output of the previous step)
4. run your actor as `snactor run --config /etc/leapp/leapp.conf --actor-config IPUConfig <ActorName (class name)> --print-output`
5. your actor will be executed with the same input messages that caused the failure