### PR TITLE
docs: Pin sphinx-rtd-theme version fixing build error

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,6 +2,6 @@
 
 CommonMark==0.7.5
 sphinx>=1.5,<1.6
-sphinx_rtd_theme
+sphinx_rtd_theme==0.4.3
 sphinx-autobuild
 git+https://github.com/leapp-to/recommonmark.git@master


### PR DESCRIPTION
Previously the 0.4.3 version was correctly used. There are still some warnings during build, but those were also present previously (verified by checking old RTD build).

Follows up on #876 - fixes required to make build on RTD working again.