### PR TITLE
Fix leaking FDs in the run (_call) function 

### DIFF
--- a/leapp/libraries/stdlib/call.py
+++ b/leapp/libraries/stdlib/call.py
@@ -202,6 +202,8 @@ def _call(command, callback_raw=lambda fd, value: None, callback_linebuffered=la
         # Wait for the child to finish
         pid, status = os.wait()
         ep.close()
+        os.close(stdout)
+        os.close(stderr)
 
         # The status variable is a 16 bit value, where the lower octet describes
         # the signal which killed the process, and the upper octet is the exit code

--- a/leapp/libraries/stdlib/call.py
+++ b/leapp/libraries/stdlib/call.py
@@ -171,9 +171,9 @@ def _call(command, callback_raw=lambda fd, value: None, callback_linebuffered=la
     elif stdin is not None:
         raise TypeError('stdin has to be either a file descriptor or string, not "{!s}"'.format(type(stdin)))
 
-    ep = EventLoop()
     pid = os.fork()
     if pid > 0:
+        ep = EventLoop()
         # Since pid > 0, we are in the parent process, so we have to close the write-end
         # file descriptors
         os.close(wstdout)


### PR DESCRIPTION
updated by @pirat89 

Original implementation of the `_call` function (used by `run` from actors) has been leaking file descriptors per each invocation. So in case an actor executed too many of them during an execution it could reach the limit of allowed opened FDs and the execution failed with `OSError: Too many opened files` error.

There have been actually 2 issues:
* `EventLoop` (alias `select.epoll`) have been called before the fork so the child process inherit the created FD too
  * that has not been so big problem actually as the child process always ended before the parent finished the function so this has been closed always safely by OS anyway. But updating it anyway to make it cleaner.
* `stdout` and `stderr` pipes (to consumes content from child process) have been created before the fork but have not been closed in the parent
  * The parent process hasn't closed related FDs so this led to the situation where 2 FDs leaked per the code execution as these have been opened until the end of the actor execution. Closing these after the `EventLoop` is closed (and death of the child process) resolved this issue.

Warning: totally untested (@pirat89 manually tested on rhel7 & rhel9)
