### PR TITLE
spec: Introduce /etc/leapp/actor_conf.d/ directory

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -184,6 +184,7 @@ install -m 0755 -d %{buildroot}%{_datadir}/leapp/report_schema
 install -m 0644 -p report-schema-v110.json %{buildroot}%{_datadir}/leapp/report_schema/report-schema.json
 install -m 0700 -d %{buildroot}%{_sharedstatedir}/leapp
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp
+install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/actor_conf.d/
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/repos.d
 install -m 0600 -d %{buildroot}%{_sysconfdir}/leapp/answers
 # standard directory should have permission set to 0755, however this directory
@@ -209,6 +210,7 @@ install -m 0644 -p man/leapp.1 %{buildroot}%{_mandir}/man1/
 %config(noreplace) %{_sysconfdir}/leapp/leapp.conf
 %config(noreplace) %{_sysconfdir}/leapp/logger.conf
 %dir %{_sysconfdir}/leapp
+%dir %{_sysconfdir}/leapp/actor_conf.d
 %dir %{_sysconfdir}/leapp/answers
 %dir %{_sysconfdir}/leapp/repos.d
 %{_bindir}/leapp


### PR DESCRIPTION
The directory should be owned by the leapp rpm so leapp actors could already use it - or existing leapp repositories packages could install some config files inside already.