### PR TITLE
Remove pytest plugin hook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,5 @@ setup(
         [console_scripts]
         snactor=leapp.snactor:main
         leapp=leapp.cli:main
-
-        [pytest11]
-        snactor_plugin=leapp.snactor.fixture
     '''
 )

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -4,3 +4,4 @@ from helpers import make_repository_dir_fixture
 # NOTE(ivasilev) Assigning a fixture generated that way to some variable is a necessary prerequisite for it to be
 # discovered by pylint
 repodir_fixture = make_repository_dir_fixture(name='repository_dir', scope='session')
+pytest_plugins = ('leapp.snactor.fixture',)


### PR DESCRIPTION
This broke all (reasonably recent pytest installations) when snactor was not installed.

Resolves: https://issues.redhat.com/browse/RHEL-74372