### PR TITLE
Fix CLI: allow to set falsy values as default

### DIFF
--- a/leapp/utils/clicmd.py
+++ b/leapp/utils/clicmd.py
@@ -228,8 +228,8 @@ class Command(object):
         :type metavar: str
         :param choices: range of values that the argument is allowed to take
         :type choices: list
-        :param choices: default value of the argument if nothing is specified
-        :type choices: str
+        :param default: default value of the argument if nothing is specified
+        :type default: any
         :return: self
         """
         name = name.lstrip('-')
@@ -250,7 +250,7 @@ class Command(object):
             kwargs['metavar'] = metavar
         if choices:
             kwargs['choices'] = choices
-        if default:
+        if default is not None:
             kwargs['default'] = default
         self._add_opt(*names, help=help,  # noqa; pylint: disable=redefined-builtin
                       action=action, internal={'wrapped': wrapped, 'inherit': inherit}, **kwargs)

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 6.0
+%global framework_version 6.1
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage


### PR DESCRIPTION
When specifying an option for a leapp CLI command using @add_option decorator, it has not been possible to specify a "falsy" value (or let's say empty) as `default` e.g. empty string, empty list, etc. Start to check NoneType for the `default` parameter properly to allow it to set this.

**Bump leapp-framework to 6.1.**

Note:
The similar problem is for `choices` and `metavar` parameters. In case of `metavar` it's however ok to ignore empty string. In case of empty `choices` it would lead to the same evaluation as in case of NoneType (any input is ok). So I that the `default` is the only parameter that needs to be checked properly.

jira: RHEL-86206