### PR TITLE
Snactor: add command to show dependencies between actors

### DIFF
--- a/leapp/snactor/commands/show_dependencies.py
+++ b/leapp/snactor/commands/show_dependencies.py
@@ -42,7 +42,7 @@ def cli(params):
     if params.only_influencing_actor:
         actor_of_interest = repository.lookup_actor(params.only_influencing_actor)
         if not actor_of_interest:
-            raise CommandError('Could not find any workflow named "{}"'.format(params.name))
+            raise CommandError('Could not find given actor named "{}"'.format(params.only_influencing_actor))
 
     workflow_instance = workflow()
 

--- a/leapp/snactor/commands/show_dependencies.py
+++ b/leapp/snactor/commands/show_dependencies.py
@@ -36,7 +36,7 @@ def cli(params):
 
     workflow = repository.lookup_workflow(params.workflow_name)
     if not workflow:
-        raise CommandError('Could not find any workflow named "{}"'.format(params.name))
+        raise CommandError('Could not find any workflow named "{}"'.format(params.workflow_name))
 
     actor_of_interest = None
     if params.only_influencing_actor:

--- a/leapp/snactor/commands/show_dependencies.py
+++ b/leapp/snactor/commands/show_dependencies.py
@@ -1,0 +1,64 @@
+import itertools
+from collections import defaultdict
+import sys
+
+from leapp.exceptions import CommandError, LeappError
+from leapp.logger import configure_logger
+from leapp.repository.scan import find_and_scan_repositories
+from leapp.snactor.context import with_snactor_context
+from leapp.utils.clicmd import command, command_arg
+from leapp.utils.repository import find_repository_basedir, requires_repository
+
+_LONG_DESCRIPTION = '''
+Outputs the graph of dependencies between actors formed by producer/consumer their relations in the DOT langauge.
+The DOT language allows easy visualization of the graph.
+'''
+
+
+@command('show-dependencies',
+         help='Print dependency graph of a workflow in the DOT language.',
+         description=_LONG_DESCRIPTION)
+@command_arg('workflow_name')
+@requires_repository
+@with_snactor_context
+def cli(params):
+    configure_logger()
+    repository = find_and_scan_repositories(find_repository_basedir('.'), include_locals=True)
+    try:
+        repository.load()
+    except LeappError as exc:
+        sys.stderr.write(exc.message)
+        sys.stderr.write('\n')
+        sys.exit(1)
+
+    workflow = repository.lookup_workflow(params.workflow_name)
+    if not workflow:
+        raise CommandError('Could not find any workflow named "{}"'.format(params.name))
+
+    workflow_instance = workflow()
+
+    # Information about message consuments and producers:
+    dependency_graph = defaultdict(lambda: {'producers': set(), 'consumers': set()})
+
+    for staged_phase in workflow_instance.phase_actors:
+        # staged_phase = ('name' <str>, 'Before' <PhaseActors>, 'Main' <PhaseActors>, 'After' <PhaseActors>)
+        before_stage, main_stage, after_stage = staged_phase[1:]
+
+        for actor in itertools.chain(before_stage.actors, main_stage.actors, after_stage.actors):
+            for consumed_message in actor.consumes:
+                dependency_graph[consumed_message.__name__]['consumers'].add(actor.name)
+            for produced_message in actor.produces:
+                dependency_graph[produced_message.__name__]['producers'].add(actor.name)
+
+    # Display the dependency graph in the DOT format. We don't want to add dependencies on another library,
+    # so we do the formatting ourselves since its pretty straightforward
+    dot_output_lines = ['digraph LeappDependencyGraph {']
+
+    for message, message_info in dependency_graph.items():
+        for producent, consument in itertools.product(message_info['producers'], message_info['consumers']):
+            output_line = '  "{0}" -> "{1}" [label="{2}"]'.format(producent, consument, message)
+            dot_output_lines.append(output_line)
+
+    dot_output_lines.append('}')
+    dot_output = '\n'.join(dot_output_lines) + '\n'
+    print(dot_output, end='')

--- a/leapp/snactor/commands/show_dependencies.py
+++ b/leapp/snactor/commands/show_dependencies.py
@@ -6,7 +6,7 @@ from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.snactor.context import with_snactor_context
-from leapp.utils.clicmd import command, command_arg
+from leapp.utils.clicmd import command, command_arg, command_opt
 from leapp.utils.repository import find_repository_basedir, requires_repository
 
 _LONG_DESCRIPTION = '''
@@ -19,6 +19,9 @@ The DOT language allows easy visualization of the graph.
          help='Print dependency graph of a workflow in the DOT language.',
          description=_LONG_DESCRIPTION)
 @command_arg('workflow_name')
+@command_opt('only-influencing-actor',
+             metavar='ActorName',
+             help='Show only actors that influence the given actor by producing messages')
 @requires_repository
 @with_snactor_context
 def cli(params):
@@ -35,6 +38,12 @@ def cli(params):
     if not workflow:
         raise CommandError('Could not find any workflow named "{}"'.format(params.name))
 
+    actor_of_interest = None
+    if params.only_influencing_actor:
+        actor_of_interest = repository.lookup_actor(params.only_influencing_actor)
+        if not actor_of_interest:
+            raise CommandError('Could not find any workflow named "{}"'.format(params.name))
+
     workflow_instance = workflow()
 
     # Information about message consuments and producers:
@@ -50,12 +59,34 @@ def cli(params):
             for produced_message in actor.produces:
                 dependency_graph[produced_message.__name__]['producers'].add(actor.name)
 
+    actors_to_include = set()
+    if actor_of_interest:
+        # Compute backwards reachability
+        worklist = [actor_of_interest.name]
+        while worklist:
+            explored_actor = worklist.pop(-1)
+            actors_to_include.add(explored_actor.name)
+
+            for consumed_message in explored_actor.consumes:
+                message_producer_names = dependency_graph[consumed_message.__name__]['producers']
+                for producer_name in message_producer_names:
+                    if producer_name in actors_to_include:
+                        continue
+
+                    producer = repository.lookup_actor(producer_name)
+                    worklist.append(producer)
+
     # Display the dependency graph in the DOT format. We don't want to add dependencies on another library,
     # so we do the formatting ourselves since its pretty straightforward
     dot_output_lines = ['digraph LeappDependencyGraph {']
 
     for message, message_info in dependency_graph.items():
         for producent, consument in itertools.product(message_info['producers'], message_info['consumers']):
+            # In case we show only influential actors, check that both message source and message targets
+            # are to be displayed
+            if actor_of_interest and not actors_to_include.issubset((producent, consument)):
+                continue
+
             output_line = '  "{0}" -> "{1}" [label="{2}"]'.format(producent, consument, message)
             dot_output_lines.append(output_line)
 

--- a/leapp/workflows/phaseactors.py
+++ b/leapp/workflows/phaseactors.py
@@ -7,7 +7,7 @@ class PhaseActors(object):
         self._actors = actors
         self._consumes = set()
         self._produces = set()
-        self._messages = {}
+        self._messages = {}  # Information about message producers for topoplogical sorting
 
         for actor in self._actors:
             self._consumes.update(actor.consumes)
@@ -22,21 +22,26 @@ class PhaseActors(object):
 
     @property
     def initial(self):
+        """ Tuple of messages that are not consumed by any actor. """
         return tuple(self._initial)
 
     @property
     def actors(self):
+        """ Tuple of actors in the execution order. """
         return tuple(self._actors)
 
     @property
     def consumes(self):
+        """ Tuple containing all messages consumed by some actor. """
         return tuple(self._consumes)
 
     @property
     def produces(self):
+        """ Tuple containing all messages produced by some actor. """
         return tuple(self._produces)
 
     def _sort(self):
+        """ Perform topological sort of the actor dependency graph for this phase, producing execution order. """
         actors, self._actors = list(self._actors), ()
         while actors:
             scheduled = []


### PR DESCRIPTION
Adds a new command `show-dependencies <workflow>` that displays all producer/consumer dependencies in the workflow. The output of the command is in the [DOT](https://graphviz.org/doc/info/lang.html) language that allows easy visualization of graphs.

Example use:
```
# snactor show-dependencies WORKFLOW > deps.dot
# xdot deps.dot
```