### PR TITLE
Replace datetime.datetime.utcnow

### DIFF
--- a/leapp/logger/__init__.py
+++ b/leapp/logger/__init__.py
@@ -25,7 +25,7 @@ class LeappAuditHandler(logging.Handler):
         log_data = {
             'event': 'log-message',
             'context': os.environ.get('LEAPP_EXECUTION_ID', 'TESTING-CONTEXT'),
-            'stamp': datetime.datetime.utcnow().isoformat() + 'Z',
+            'stamp': datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             'hostname': os.environ.get('LEAPP_HOSTNAME', 'localhost'),
             'actor': os.environ.get('LEAPP_CURRENT_ACTOR', ''),
             'phase': os.environ.get('LEAPP_CURRENT_PHASE', ''),

--- a/leapp/messaging/__init__.py
+++ b/leapp/messaging/__init__.py
@@ -229,7 +229,7 @@ class BaseMessaging(object):
             'type': type(model).__name__,
             'actor': type(actor).name if not isinstance(actor, str) else actor,
             'topic': model.topic.name,
-            'stamp': datetime.datetime.utcnow().isoformat() + 'Z',
+            'stamp': datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             'phase': os.environ.get('LEAPP_CURRENT_PHASE', 'NON-WORKFLOW-EXECUTION'),
             'context': os.environ.get('LEAPP_EXECUTION_ID', 'TESTING-CONTEXT'),
             'hostname': os.environ['LEAPP_HOSTNAME'],

--- a/leapp/utils/audit/__init__.py
+++ b/leapp/utils/audit/__init__.py
@@ -125,7 +125,7 @@ class Execution(Storable):
         :type stamp: str
         """
         super(Execution, self).__init__()
-        self.stamp = stamp or datetime.datetime.utcnow().isoformat() + 'Z'
+        self.stamp = stamp or datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         if not isinstance(configuration, string_types):
             configuration = json.dumps(configuration, sort_keys=True)
         self.configuration = configuration
@@ -374,7 +374,7 @@ class Message(DataSource):
         :type hostname: str
         """
         super(Message, self).__init__(actor=actor, phase=phase, hostname=hostname, context=context)
-        self.stamp = stamp or datetime.datetime.utcnow().isoformat() + 'Z'
+        self.stamp = stamp or datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.msg_type = msg_type
         self.topic = topic
         self.data = data
@@ -515,7 +515,7 @@ class Audit(DataSource):
         """
         super(Audit, self).__init__(actor=actor, phase=phase, hostname=hostname, context=context)
         self.event = event
-        self.stamp = stamp or datetime.datetime.utcnow().isoformat() + 'Z'
+        self.stamp = stamp or datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.message = message
         self.data = data
         self._audit_id = None


### PR DESCRIPTION
The datetime.datetime.utcnow() function is marked as reprecated and will be removed un future python release. As we dopped support for Python2, let's replace the function everywhere.

- [ ] Check storing of other timestamps in leapp to be sure we use just one one same timestamp format for everything