### PR TITLE
Run leapp in Python Isolated mode (update shebang)

### DIFF
--- a/leapp/cli/__main__.py
+++ b/leapp/cli/__main__.py
@@ -1,4 +1,3 @@
-
 from leapp.cli import main
 import leapp.utils.i18n  # noqa: F401; pylint: disable=unused-import
 

--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -39,6 +39,7 @@
   # we have to drop the dependency on python(abi) completely on el8+ because
   # of IPU (python abi is different between systems)
   %global __requires_exclude ^python\\(abi\\) = 3\\..+|/usr/libexec/platform-python|/usr/bin/python.*
+  %global py3_shebang_flags %{expand:%py3_shebang_flags}I
 %endif
 
 Name:       leapp
@@ -196,6 +197,7 @@ install -m 0644 etc/leapp/*.conf %{buildroot}%{_sysconfdir}/leapp
 install -m 0644 -p man/leapp.1 %{buildroot}%{_mandir}/man1/
 
 %{leapp_py_install}
+%py3_shebang_fix %{buildroot}%{_bindir}/leapp
 
 
 ##################################################


### PR DESCRIPTION
Originally, leapp was usually executed only with `<platform-python>`, without any additional Python parameters. However, this led to various problems when running leapp on systems with additional third-party (or custom) Python libraries that could override the original libraries provided by the Linux distribution in use.

For that reason, we decided to update the shebang in the `/usr/bin/leapp` executable provided by the leapp RPM, so that leapp starts in isolated Python mode and ignores the user's environment.

Note that the current shebang contains a duplicated `I` parameter. As this does not have any functional impact, and we could not come up with a solution in the SPEC file to fix it, we decided to keep it as is.