### PR TITLE
cli: Add possibility to specify aliases for CLI option

### DIFF
--- a/packaging/leapp.spec
+++ b/packaging/leapp.spec
@@ -13,7 +13,7 @@
 # This is kind of help for more flexible development of leapp repository,
 # so people do not have to wait for new official release of leapp to ensure
 # it is installed/used the compatible one.
-%global framework_version 6.1
+%global framework_version 6.2
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage


### PR DESCRIPTION
The existing 'name' and 'short_name' parameters are kept as is for backwards compatibility.

Also a dest parameter is added for specifying the name of the attribute to be added to the parsed args object.

The change is backwards compatible, bump the `framework-version` to 6.2.

Jira: RHEL-110563 (related)

---
#### Example help text:
```
[root@localhost ~]# leapp upgrade --help
usage: leapp upgrade [-h] [--nogpgcheck] [--report-schema {1.0.0,1.1.0,1.2.0}] [--target-os {rhel,centos,almalinux}]
                     [--target TARGET_VERSION] [--iso ISO] [--channel {ga,e4s,eus,aus}] [--enablerepo <repoid>]
                     [--no-rhsm-facts] [--no-insights-register] [--no-rhsm] [--verbose] [--debug]
                     [--enable-experimental-feature Feature] [--whitelist-experimental ActorName] [--reboot]
                     [--resume]

Description:

Upgrade the current system to the next available major version.

Optional arguments:
  -h, --help            show this help message and exit
  --nogpgcheck          Disable RPM GPG checks. Same as yum/dnf --nogpgcheck option.
  --report-schema {1.0.0,1.1.0,1.2.0}
                        Specify report schema version for leapp-report.json
  --target TARGET_VERSION, --target-version TARGET_VERSION                                        <------
                        Specify RHEL version to upgrade to for default detected upgrade flavour

```
The alias is listed after the `name` and the argument "hint" (TARGET_VERSION) is created from `dest` which is `target_version`.
The option is defined like this:
```python
@command_opt(
    'target',
    help='Specify RHEL version to upgrade to for {} detected upgrade flavour'.format(
        command_utils.get_upgrade_flavour()
    ),
    aliases=['target-version'],
    dest='target_version',
)
```