### PR TITLE
python test deps: update pytest requirements

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,4 +7,6 @@ jsonschema==3.2.0
 mock
 pylint
 pytest-cov
-pytest==6.2.5
+pytest==6.2.5; python_version < '3.8'
+pytest==7.4.4; python_version >= '3.8' and python_version < '3.10'
+pytest==9.0.3; python_version >= '3.10'


### PR DESCRIPTION
Originally we required pytest v6.2.5 for any python. This is pretty old requirement coming from time of python ~ 3.8 and recently a CVE-2025-71176 occuared, which is fix in pytest v9.0.3. So let's update ranges to actually allow use of newer pytest on newer systems:

      +----------------+---------------+
      | pytest version | python range  |
      +----------------+---------------+
      | 6.2.5          | 3 - 3.6.x     |
      | 7.4.4          | 3.8.x - 3.9.x |
      | 9.0.3          | 3.10+         |
      +----------------+---------------+