### PR TITLE
Improve Config definition API

### DIFF
--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -389,7 +389,7 @@ class Actor(object):
         :return: Dictionary containing requested configuration.
         :rtype: dict
         """
-        return retrieve_config(self.config_schema)
+        return retrieve_config(self.config_schemas)
 
 
 def _is_type(value_type):

--- a/leapp/actors/__init__.py
+++ b/leapp/actors/__init__.py
@@ -384,7 +384,7 @@ class Actor(object):
 
     def retrieve_config(self):
         """
-        Retrieve the configuration described by self.config_schema.
+        Retrieve the configuration described by self.config_schemas.
 
         :return: Dictionary containing requested configuration.
         :rtype: dict

--- a/leapp/actors/config.py
+++ b/leapp/actors/config.py
@@ -25,7 +25,7 @@ from collections import defaultdict
 
 import yaml
 
-from leapp.models.fields import ModelViolationError
+from leapp.models.fields import Field, ModelViolationError
 
 
 try:
@@ -52,6 +52,12 @@ class SchemaError(Exception):
 class ValidationError(Exception):
     """
     Raised when a config file fails to validate against any of the available schemas.
+    """
+
+
+class ConfigDefinitionError(Exception):
+    """
+    Raised when a Config definition is invalid.
     """
 
 
@@ -91,6 +97,42 @@ class Config:
     """
     The default value for the field
     """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        required_non_null_fields = [
+            "section",
+            "name",
+            "description",
+            "type_",
+            "default",
+        ]
+
+        for field in required_non_null_fields:
+            if field not in cls.__dict__:
+                raise ConfigDefinitionError(
+                    f"{cls.__name__} must explicitly override {field}"
+                )
+            if cls.__dict__[field] is None:
+                raise ConfigDefinitionError(
+                    f"{cls.__name__}.{field} must not be None"
+                )
+
+        type_ = cls.__dict__["type_"]
+        if not isinstance(type_, Field) or type(type_) is Field:
+            raise ConfigDefinitionError(
+                f"{cls.__name__}.type_ must be an instance of a subclass of leapp.models.Field"
+            )
+
+        # TODO: expose the default publicly in Field
+        if type_._default is not None:
+            # maybe just warn? _lint_warn is private in leapp/actors/__init__.py but could be used
+            # but maybe the best solution would be to just use the default from the field and drop
+            # the default class var altogether
+            raise ConfigDefinitionError(
+                f"{cls.__name__}.type_ is assigned a Field with non-null default=, use 'default' instead."
+            )
 
     @classmethod
     def to_dict(cls):

--- a/leapp/actors/config.py
+++ b/leapp/actors/config.py
@@ -18,13 +18,11 @@ Config files are any yaml files in /etc/leapp/actor_config.d/
 """
 __metaclass__ = type
 
-import abc
 import glob
 import logging
 import os.path
 from collections import defaultdict
 
-import six
 import yaml
 
 from leapp.models.fields import ModelViolationError
@@ -57,10 +55,6 @@ class ValidationError(Exception):
     """
 
 
-# pylint: disable=deprecated-decorator
-# @abc.abstractproperty is deprecated in newer Python3 versions but it's
-# necessary for Python <= 3.3 (including 2.7)
-@six.add_metaclass(abc.ABCMeta)
 class Config:
     """
     An Actor config schema looks like this.
@@ -69,29 +63,34 @@ class Config:
         class RHUIConfig(Config):
             section = "rhui"
             name = "file_map"
-            type_ = fields.Map(fields.String())
+            type_ = fields.StringMap(fields.String())
             description = 'Description here'
             default = {"repo": "url"}
     """
-    @abc.abstractproperty
-    def section(self):
-        pass
+    section = None
+    """
+    Name of the section this field belongs to (str)
+    """
 
-    @abc.abstractproperty
-    def name(self):
-        pass
+    name = None
+    """
+    Name of the config field (the setting) (str)
+    """
 
-    @abc.abstractproperty
-    def type_(self):
-        pass
+    type_ = None
+    """
+    The type that values for this field must be of. Must be a subclass of :py:class:`leapp.models.fields.Field`.
+    """
 
-    @abc.abstractproperty
-    def description(self):
-        pass
+    description = None
+    """
+    A description of the field (str)
+    """
 
-    @abc.abstractproperty
-    def default(self):
-        pass
+    default = None
+    """
+    The default value for the field
+    """
 
     @classmethod
     def to_dict(cls):
@@ -123,7 +122,6 @@ class Config:
             'description': cls.description,
             'default': cls.default,
         }
-# pylint: enable=deprecated-decorator
 
 
 def _merge_config(configuration, new_config):

--- a/leapp/actors/config.py
+++ b/leapp/actors/config.py
@@ -98,6 +98,12 @@ class Config:
     The default value for the field
     """
 
+
+    def __new__(cls, *args, **kwargs):
+        raise TypeError(
+            f"Subclasses of {Config.__name__} cannot be instantiated"
+        )
+
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 

--- a/leapp/actors/config.py
+++ b/leapp/actors/config.py
@@ -98,7 +98,6 @@ class Config:
     The default value for the field
     """
 
-
     def __new__(cls, *args, **kwargs):
         raise TypeError(
             f"Subclasses of {Config.__name__} cannot be instantiated"


### PR DESCRIPTION
Found some annoyances when working with the Config API, the commit msgs should have all the info. 

I think it should be essentially backwards compatible with the previous version + the added checks which when violated would either way result in an error elsewhere.

There is also a fix for AttributeError in retrieve_config.

TODO tests